### PR TITLE
[P5] reviewer: scaffold + Anthropic prompt + review() API

### DIFF
--- a/packages/reviewer/package.json
+++ b/packages/reviewer/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@butaosuinu/harness-reviewer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
+    "@butaosuinu/harness-shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.3",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.5"
+  }
+}

--- a/packages/reviewer/src/__tests__/prompt.test.ts
+++ b/packages/reviewer/src/__tests__/prompt.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import type { DiffFile } from '@butaosuinu/harness-shared'
+import {
+  SYSTEM_PROMPT_TEMPLATE,
+  buildSystemPrompt,
+  serializeDiff,
+} from '../prompt.js'
+
+describe('buildSystemPrompt', () => {
+  it('injects focus areas as a bullet list', () => {
+    const prompt = buildSystemPrompt([
+      'security vulnerabilities',
+      'logic errors',
+    ])
+    expect(prompt).toContain('- security vulnerabilities')
+    expect(prompt).toContain('- logic errors')
+    expect(prompt).not.toContain('{focus_areas}')
+  })
+
+  it('uses "(none specified)" placeholder when focus areas are empty', () => {
+    const prompt = buildSystemPrompt([])
+    expect(prompt).toContain('- (none specified)')
+    expect(prompt).not.toContain('{focus_areas}')
+  })
+
+  it('preserves the template around the placeholder', () => {
+    const prompt = buildSystemPrompt(['x'])
+    expect(prompt).toContain(
+      'You are a code reviewer for an automated CI pipeline.',
+    )
+    expect(prompt).toContain('Scoring guide:')
+    expect(prompt).toContain(
+      'Note: This diff has already passed static analysis',
+    )
+  })
+
+  it('only replaces the placeholder once', () => {
+    const occurrences = SYSTEM_PROMPT_TEMPLATE.split('{focus_areas}').length - 1
+    expect(occurrences).toBe(1)
+  })
+})
+
+describe('serializeDiff', () => {
+  const file: DiffFile = {
+    filename: 'src/app.ts',
+    status: 'modified',
+    additions: 3,
+    deletions: 1,
+    patch: '@@ -1 +1 @@\n-old\n+new',
+  }
+
+  it('formats a single file with header and patch', () => {
+    const out = serializeDiff([file])
+    expect(out).toBe(
+      '=== src/app.ts (modified, +3/-1) ===\n@@ -1 +1 @@\n-old\n+new',
+    )
+  })
+
+  it('joins multiple files with blank line separators', () => {
+    const other: DiffFile = {
+      filename: 'README.md',
+      status: 'added',
+      additions: 10,
+      deletions: 0,
+      patch: '+# Title',
+    }
+    const out = serializeDiff([file, other])
+    expect(out).toContain('=== src/app.ts (modified, +3/-1) ===')
+    expect(out).toContain('=== README.md (added, +10/-0) ===')
+    expect(out.split('\n\n').length).toBe(2)
+  })
+
+  it('falls back to placeholder text when patch is missing', () => {
+    const noPatch: DiffFile = {
+      filename: 'bin/tool',
+      status: 'added',
+      additions: 0,
+      deletions: 0,
+    }
+    const out = serializeDiff([noPatch])
+    expect(out).toContain('(no patch available)')
+  })
+
+  it('returns an empty string for an empty diff', () => {
+    expect(serializeDiff([])).toBe('')
+  })
+})

--- a/packages/reviewer/src/__tests__/review.test.ts
+++ b/packages/reviewer/src/__tests__/review.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DiffFile, HarnessConfig, ReviewResult } from '@butaosuinu/harness-shared'
+import { HarnessConfigSchema } from '@butaosuinu/harness-shared'
+
+const createMock = vi.fn()
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class MockAnthropic {
+    messages = { create: createMock }
+    constructor(_opts: unknown) {}
+  }
+  return { default: MockAnthropic }
+})
+
+import { DEFAULT_MODEL, MissingApiKeyError, review } from '../index.js'
+
+const baseConfig: HarnessConfig = HarnessConfigSchema.parse({
+  harness: {
+    version: '1',
+    risk_rules: {
+      high: {
+        file_patterns: [],
+        ast_rules: [],
+        dependency_rules: { added_packages: [] },
+        diff_size: { max_files: 20, max_lines: 500 },
+      },
+      low: { file_patterns: [] },
+    },
+    ai_review: {
+      focus_areas: ['security vulnerabilities', 'logic errors'],
+    },
+  },
+})
+
+const diff: DiffFile[] = [
+  {
+    filename: 'src/a.ts',
+    status: 'modified',
+    additions: 2,
+    deletions: 1,
+    patch: '@@ -1 +1 @@\n-a\n+b',
+  },
+]
+
+const validReview: ReviewResult = {
+  score: 92,
+  summary: 'Looks clean.',
+  concerns: [
+    { file: 'src/a.ts', line: 10, severity: 'low', message: 'consider a comment' },
+  ],
+  recommendation: 'approve',
+}
+
+function textResponse(text: string) {
+  return { content: [{ type: 'text', text }] }
+}
+
+beforeEach(() => {
+  createMock.mockReset()
+})
+
+describe('review()', () => {
+  it('returns parsed ReviewResult on happy path', async () => {
+    createMock.mockResolvedValueOnce(textResponse(JSON.stringify(validReview)))
+
+    const result = await review({
+      diff,
+      config: baseConfig,
+      apiKey: 'sk-test',
+    })
+
+    expect(result).toEqual(validReview)
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const call = createMock.mock.calls[0]![0]
+    expect(call.model).toBe(DEFAULT_MODEL)
+    expect(call.temperature).toBe(0)
+    expect(call.system).toContain('- security vulnerabilities')
+    expect(call.system).toContain('- logic errors')
+    expect(call.messages).toEqual([
+      { role: 'user', content: expect.stringContaining('src/a.ts') },
+    ])
+  })
+
+  it('retries once with a corrective user turn when JSON is broken, then succeeds', async () => {
+    createMock
+      .mockResolvedValueOnce(textResponse('not json at all'))
+      .mockResolvedValueOnce(textResponse(JSON.stringify(validReview)))
+
+    const result = await review({
+      diff,
+      config: baseConfig,
+      apiKey: 'sk-test',
+    })
+
+    expect(result).toEqual(validReview)
+    expect(createMock).toHaveBeenCalledTimes(2)
+    const secondCall = createMock.mock.calls[1]![0]
+    expect(secondCall.messages).toHaveLength(3)
+    expect(secondCall.messages[1]).toEqual({
+      role: 'assistant',
+      content: 'not json at all',
+    })
+    expect(secondCall.messages[2].role).toBe('user')
+    expect(secondCall.messages[2].content).toMatch(/not valid JSON/i)
+  })
+
+  it('falls back to request_changes when both attempts return broken JSON', async () => {
+    createMock
+      .mockResolvedValueOnce(textResponse('nope'))
+      .mockResolvedValueOnce(textResponse('{still not valid'))
+
+    const result = await review({
+      diff,
+      config: baseConfig,
+      apiKey: 'sk-test',
+    })
+
+    expect(createMock).toHaveBeenCalledTimes(2)
+    expect(result.score).toBe(0)
+    expect(result.recommendation).toBe('request_changes')
+    expect(result.concerns).toEqual([])
+    expect(result.summary.toLowerCase()).toContain('retry')
+  })
+
+  it('falls back when response JSON fails shape validation', async () => {
+    createMock
+      .mockResolvedValueOnce(
+        textResponse(JSON.stringify({ score: 'high', summary: 'x', concerns: [], recommendation: 'approve' })),
+      )
+      .mockResolvedValueOnce(
+        textResponse(JSON.stringify({ score: 80, summary: 'x', concerns: [], recommendation: 'merge' })),
+      )
+
+    const result = await review({
+      diff,
+      config: baseConfig,
+      apiKey: 'sk-test',
+    })
+
+    expect(result.score).toBe(0)
+    expect(result.recommendation).toBe('request_changes')
+  })
+
+  it('uses input.model override when provided', async () => {
+    createMock.mockResolvedValueOnce(textResponse(JSON.stringify(validReview)))
+
+    await review({
+      diff,
+      config: baseConfig,
+      apiKey: 'sk-test',
+      model: 'claude-opus-4-7',
+    })
+
+    expect(createMock.mock.calls[0]![0].model).toBe('claude-opus-4-7')
+  })
+
+  it('throws MissingApiKeyError for empty apiKey', async () => {
+    await expect(
+      review({ diff, config: baseConfig, apiKey: '' }),
+    ).rejects.toBeInstanceOf(MissingApiKeyError)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('throws MissingApiKeyError for whitespace-only apiKey', async () => {
+    await expect(
+      review({ diff, config: baseConfig, apiKey: '   ' }),
+    ).rejects.toBeInstanceOf(MissingApiKeyError)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/reviewer/src/errors.ts
+++ b/packages/reviewer/src/errors.ts
@@ -1,0 +1,6 @@
+export class MissingApiKeyError extends Error {
+  constructor(message = 'ANTHROPIC_API_KEY is required for AI review') {
+    super(message)
+    this.name = 'MissingApiKeyError'
+  }
+}

--- a/packages/reviewer/src/index.ts
+++ b/packages/reviewer/src/index.ts
@@ -1,0 +1,127 @@
+import Anthropic from '@anthropic-ai/sdk'
+import type {
+  DiffFile,
+  HarnessConfig,
+  ReviewConcern,
+  ReviewResult,
+} from '@butaosuinu/harness-shared'
+
+import { MissingApiKeyError } from './errors.js'
+import { buildSystemPrompt, serializeDiff } from './prompt.js'
+
+export { MissingApiKeyError } from './errors.js'
+export {
+  SYSTEM_PROMPT_TEMPLATE,
+  buildSystemPrompt,
+  serializeDiff,
+} from './prompt.js'
+
+export const DEFAULT_MODEL = 'claude-sonnet-4-6'
+const MAX_TOKENS = 2048
+const RETRY_CORRECTION =
+  'Your previous response was not valid JSON. Respond ONLY with a JSON object matching the schema, no prose, no markdown fences.'
+
+type Message = {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export interface ReviewInput {
+  diff: readonly DiffFile[]
+  config: HarnessConfig
+  apiKey: string
+  model?: string
+}
+
+export async function review(input: ReviewInput): Promise<ReviewResult> {
+  if (!input.apiKey || input.apiKey.trim() === '') {
+    throw new MissingApiKeyError()
+  }
+
+  const client = new Anthropic({ apiKey: input.apiKey })
+  const model = input.model ?? DEFAULT_MODEL
+  const system = buildSystemPrompt(input.config.harness.ai_review.focus_areas)
+  const userContent = serializeDiff(input.diff)
+
+  const firstMessages: Message[] = [{ role: 'user', content: userContent }]
+  const firstText = await callModel(client, model, system, firstMessages)
+  const firstParsed = tryParseReview(firstText)
+  if (firstParsed) return firstParsed
+
+  const retryMessages: Message[] = [
+    ...firstMessages,
+    { role: 'assistant', content: firstText },
+    { role: 'user', content: RETRY_CORRECTION },
+  ]
+  const secondText = await callModel(client, model, system, retryMessages)
+  const secondParsed = tryParseReview(secondText)
+  if (secondParsed) return secondParsed
+
+  return {
+    score: 0,
+    summary:
+      'AI review returned invalid JSON after one retry; defaulting to request_changes.',
+    concerns: [],
+    recommendation: 'request_changes',
+  }
+}
+
+async function callModel(
+  client: Anthropic,
+  model: string,
+  system: string,
+  messages: Message[],
+): Promise<string> {
+  const response = await client.messages.create({
+    model,
+    max_tokens: MAX_TOKENS,
+    temperature: 0,
+    system,
+    messages,
+  })
+  for (const block of response.content) {
+    if (block.type === 'text') return block.text
+  }
+  return ''
+}
+
+function tryParseReview(raw: string): ReviewResult | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!isRecord(parsed)) return null
+
+  const { score, summary, concerns, recommendation } = parsed
+  if (typeof score !== 'number' || !Number.isFinite(score)) return null
+  if (typeof summary !== 'string') return null
+  if (recommendation !== 'approve' && recommendation !== 'request_changes') {
+    return null
+  }
+  if (!Array.isArray(concerns)) return null
+
+  const validated: ReviewConcern[] = []
+  for (const c of concerns) {
+    if (!isRecord(c)) return null
+    if (typeof c.file !== 'string') return null
+    if (typeof c.line !== 'number') return null
+    if (c.severity !== 'low' && c.severity !== 'medium' && c.severity !== 'high') {
+      return null
+    }
+    if (typeof c.message !== 'string') return null
+    validated.push({
+      file: c.file,
+      line: c.line,
+      severity: c.severity,
+      message: c.message,
+    })
+  }
+
+  return { score, summary, concerns: validated, recommendation }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/reviewer/src/prompt.ts
+++ b/packages/reviewer/src/prompt.ts
@@ -1,0 +1,48 @@
+import type { DiffFile } from '@butaosuinu/harness-shared'
+
+export const SYSTEM_PROMPT_TEMPLATE = `You are a code reviewer for an automated CI pipeline.
+Your role is to evaluate whether the code changes in this PR are safe to auto-merge.
+
+Evaluate the diff and respond ONLY with a JSON object (no markdown, no explanation):
+{
+  "score": <integer 0-100>,
+  "summary": "<one sentence overall assessment>",
+  "concerns": [
+    {
+      "file": "<filename>",
+      "line": <line number or 0 if not applicable>,
+      "severity": "low" | "medium" | "high",
+      "message": "<specific actionable concern>"
+    }
+  ],
+  "recommendation": "approve" | "request_changes"
+}
+
+Scoring guide:
+- 90-100: Clean, well-tested, no concerns
+- 75-89: Minor issues, safe to auto-merge
+- 50-74: Notable concerns, human review recommended
+- 0-49: Significant issues, do not auto-merge
+
+Focus areas (from config):
+{focus_areas}
+
+Note: This diff has already passed static analysis (no schema changes, no auth changes, no secrets).`
+
+export function buildSystemPrompt(focusAreas: readonly string[]): string {
+  const bullets =
+    focusAreas.length === 0
+      ? '- (none specified)'
+      : focusAreas.map((area) => `- ${area}`).join('\n')
+  return SYSTEM_PROMPT_TEMPLATE.replace('{focus_areas}', bullets)
+}
+
+export function serializeDiff(files: readonly DiffFile[]): string {
+  return files
+    .map((file) => {
+      const header = `=== ${file.filename} (${file.status}, +${file.additions}/-${file.deletions}) ===`
+      const body = file.patch ?? '(no patch available)'
+      return `${header}\n${body}`
+    })
+    .join('\n\n')
+}

--- a/packages/reviewer/tsconfig.json
+++ b/packages/reviewer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/__tests__/**"]
+}

--- a/packages/reviewer/tsup.config.ts
+++ b/packages/reviewer/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: 'node20',
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,28 @@ importers:
         specifier: ^2.1.5
         version: 2.1.9(@types/node@22.19.17)
 
+  packages/reviewer:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.90.0
+        version: 0.90.0(zod@3.25.76)
+      '@butaosuinu/harness-shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.3
+        version: 22.19.17
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.5
+        version: 2.1.9(@types/node@22.19.17)
+
   packages/shared:
     dependencies:
       zod:
@@ -113,6 +135,19 @@ importers:
         version: 2.1.9(@types/node@22.19.17)
 
 packages:
+
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -961,6 +996,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -1198,6 +1237,9 @@ packages:
   tree-sitter@0.21.1:
     resolution: {integrity: sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -1315,6 +1357,14 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.90.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@babel/runtime@7.29.2': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1973,6 +2023,11 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -2196,6 +2251,8 @@ snapshots:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4
     optional: true
+
+  ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 


### PR DESCRIPTION
## Summary
- 新規 `packages/reviewer` を `@butaosuinu/harness-reviewer` として追加。classifier の雛形を踏襲（tsup + vitest + tsconfig.base）。
- `plan.md` L448-481 のシステムプロンプトを `SYSTEM_PROMPT_TEMPLATE` / `buildSystemPrompt(focusAreas)` として実装。`config.harness.ai_review.focus_areas` を箇条書きで注入。
- `review(input)` が `@anthropic-ai/sdk` で Claude (`claude-sonnet-4-6`, `temperature: 0`) を呼び、JSON を `ReviewResult` にパース。壊れた JSON は修正 user turn 付きで 1 回リトライし、それでも失敗なら `{ score: 0, recommendation: 'request_changes' }` にフォールバック。
- `apiKey` が空 / 空白のみなら `MissingApiKeyError` を throw（#17 で graceful に捕捉される想定）。
- 15 件の vitest unit test (Anthropic SDK は `vi.mock`): happy path / retry-then-succeed / retry-then-fallback / shape validation fallback / model override / missing key (空・空白)。

## Test plan
- [x] `pnpm -F @butaosuinu/harness-reviewer test` — 15/15 passed
- [x] `pnpm -F @butaosuinu/harness-reviewer lint` (tsc --noEmit) clean
- [x] `pnpm -F @butaosuinu/harness-reviewer build` — ESM/CJS/DTS 出力確認
- [x] `pnpm -r test` — shared/classifier/cli にリグレッション無し (49 tests total)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)