### PR TITLE
feat(actions): auto-merge composite action + @butaosuinu/harness-auto-merge

### DIFF
--- a/actions/auto-merge/action.yml
+++ b/actions/auto-merge/action.yml
@@ -4,6 +4,7 @@ description: >-
   Adds a harness:auto-merged label on success, or comments on the PR and
   fails the action on conflict or CI failure.
 author: harness
+
 inputs:
   github-token:
     description: GitHub token with contents:write and pull-requests:write.
@@ -22,18 +23,65 @@ inputs:
     description: Label applied to the PR on successful auto-merge.
     required: false
     default: harness:auto-merged
+  cli-source:
+    description: |
+      Where to obtain @butaosuinu/harness-auto-merge.
+        "npm"       — npx the published package (default; requires the package to be published).
+        "workspace" — build from the harness repo's pnpm workspace checked out alongside this action.
+                      Use this mode while the package is still private / unpublished.
+    required: false
+    default: npm
+  node-version:
+    description: Node.js version to set up.
+    required: false
+    default: '20'
+  pnpm-version:
+    description: pnpm version to set up (used only when cli-source == workspace).
+    required: false
+    default: '10'
+
 runs:
   using: composite
   steps:
-    - name: Setup Node.js
+    - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: ${{ inputs.node-version }}
+
+    - name: Set up pnpm (workspace mode)
+      if: inputs.cli-source == 'workspace'
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - name: Build harness-auto-merge from workspace
+      if: inputs.cli-source == 'workspace'
+      shell: bash
+      working-directory: ${{ github.action_path }}/../..
+      run: |
+        set -euo pipefail
+        pnpm install --frozen-lockfile
+        pnpm --filter @butaosuinu/harness-auto-merge... build
+
     - name: Run harness auto-merge
       shell: bash
-      run: npx --yes @butaosuinu/harness-auto-merge@latest
       env:
+        HARNESS_CLI_SOURCE: ${{ inputs.cli-source }}
+        HARNESS_ACTION_REPO_ROOT: ${{ github.action_path }}/../..
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_STRATEGY: ${{ inputs.strategy }}
         INPUT_REQUIRE_CI_PASS: ${{ inputs.require-ci-pass }}
         INPUT_AUTO_MERGED_LABEL: ${{ inputs.auto-merged-label }}
+      run: |
+        set -euo pipefail
+
+        if [ "$HARNESS_CLI_SOURCE" = "workspace" ]; then
+          pnpm --dir "$HARNESS_ACTION_REPO_ROOT" \
+            --filter @butaosuinu/harness-auto-merge exec -- \
+            harness-auto-merge
+        elif [ "$HARNESS_CLI_SOURCE" = "npm" ]; then
+          npx --yes @butaosuinu/harness-auto-merge@latest
+        else
+          echo "::error::invalid cli-source: '$HARNESS_CLI_SOURCE' (expected 'npm' or 'workspace')"
+          exit 1
+        fi

--- a/actions/auto-merge/action.yml
+++ b/actions/auto-merge/action.yml
@@ -1,0 +1,39 @@
+name: Harness Auto-merge
+description: >-
+  Merges a pull request classified as low-risk with a passing AI review.
+  Adds a harness:auto-merged label on success, or comments on the PR and
+  fails the action on conflict or CI failure.
+author: harness
+inputs:
+  github-token:
+    description: GitHub token with contents:write and pull-requests:write.
+    required: true
+  strategy:
+    description: Merge strategy (squash | merge | rebase).
+    required: false
+    default: squash
+  require-ci-pass:
+    description: >-
+      When 'true', verify that all commit statuses and check runs on the
+      head SHA are green before merging. Defaults to 'true'.
+    required: false
+    default: 'true'
+  auto-merged-label:
+    description: Label applied to the PR on successful auto-merge.
+    required: false
+    default: harness:auto-merged
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: Run harness auto-merge
+      shell: bash
+      run: npx --yes @butaosuinu/harness-auto-merge@latest
+      env:
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_STRATEGY: ${{ inputs.strategy }}
+        INPUT_REQUIRE_CI_PASS: ${{ inputs.require-ci-pass }}
+        INPUT_AUTO_MERGED_LABEL: ${{ inputs.auto-merged-label }}

--- a/packages/auto-merge/package.json
+++ b/packages/auto-merge/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@butaosuinu/harness-auto-merge",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "bin": {
+    "harness-auto-merge": "./dist/run.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@octokit/rest": "^21.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.3",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.5"
+  }
+}

--- a/packages/auto-merge/src/__tests__/auto-merge.test.ts
+++ b/packages/auto-merge/src/__tests__/auto-merge.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi } from 'vitest'
+import { autoMerge, type OctokitLike } from '../auto-merge.js'
+
+interface PullOverrides {
+  state?: string
+  mergeable?: boolean | null
+  mergeable_state?: string
+  draft?: boolean
+  sha?: string
+}
+
+function buildOctokit(opts: {
+  pull?: PullOverrides
+  combinedState?: 'success' | 'pending' | 'failure'
+  combinedStatuses?: Array<{ context: string; state: string }>
+  checkRuns?: Array<{ name: string; status: string; conclusion: string | null }>
+  mergeResponse?: { sha: string; merged: boolean }
+  mergeError?: { status?: number; message?: string }
+}) {
+  const pull = {
+    head: { sha: opts.pull?.sha ?? 'deadbeef' },
+    state: opts.pull?.state ?? 'open',
+    mergeable: opts.pull?.mergeable ?? true,
+    mergeable_state: opts.pull?.mergeable_state ?? 'clean',
+    draft: opts.pull?.draft ?? false,
+  }
+
+  const getCombinedStatusForRef = vi.fn(async () => ({
+    data: {
+      state: opts.combinedState ?? 'success',
+      statuses: opts.combinedStatuses ?? [],
+    },
+  }))
+  const listForRef = vi.fn(async () => ({
+    data: { check_runs: opts.checkRuns ?? [] },
+  }))
+  const merge = vi.fn(async () => {
+    if (opts.mergeError) {
+      throw Object.assign(new Error(opts.mergeError.message ?? 'merge failed'), {
+        status: opts.mergeError.status,
+      })
+    }
+    return { data: opts.mergeResponse ?? { sha: 'merged-sha', merged: true } }
+  })
+  const get = vi.fn(async () => ({ data: pull }))
+  const addLabels = vi.fn(async () => ({}))
+  const createComment = vi.fn(async () => ({}))
+
+  const octokit: OctokitLike = {
+    rest: {
+      pulls: { get, merge },
+      repos: { getCombinedStatusForRef },
+      checks: { listForRef },
+      issues: { addLabels, createComment },
+    },
+  }
+
+  return { octokit, spies: { get, merge, addLabels, createComment, getCombinedStatusForRef, listForRef } }
+}
+
+const baseInput = {
+  owner: 'octo',
+  repo: 'harness',
+  pullNumber: 42,
+  strategy: 'squash' as const,
+  requireCiPass: true,
+  autoMergedLabel: 'harness:auto-merged',
+}
+
+describe('autoMerge', () => {
+  it('merges the PR and applies the auto-merged label when CI is green', async () => {
+    const { octokit, spies } = buildOctokit({
+      combinedState: 'success',
+      checkRuns: [{ name: 'ci', status: 'completed', conclusion: 'success' }],
+      mergeResponse: { sha: 'final-sha', merged: true },
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result).toEqual({ status: 'merged', sha: 'final-sha' })
+    expect(spies.merge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'octo',
+        repo: 'harness',
+        pull_number: 42,
+        merge_method: 'squash',
+      }),
+    )
+    expect(spies.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 42,
+        labels: ['harness:auto-merged'],
+      }),
+    )
+    expect(spies.createComment).not.toHaveBeenCalled()
+  })
+
+  it('blocks and comments when combined CI status is failing', async () => {
+    const { octokit, spies } = buildOctokit({
+      combinedState: 'failure',
+      combinedStatuses: [
+        { context: 'lint', state: 'failure' },
+        { context: 'test', state: 'success' },
+      ],
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result.status).toBe('blocked')
+    expect(spies.merge).not.toHaveBeenCalled()
+    expect(spies.addLabels).not.toHaveBeenCalled()
+    expect(spies.createComment).toHaveBeenCalledTimes(1)
+    const [{ body }] = spies.createComment.mock.calls[0] as [{ body: string }]
+    expect(body).toContain('<!-- harness[auto-merge] -->')
+    expect(body).toContain('lint')
+  })
+
+  it('blocks when a check run is still in progress', async () => {
+    const { octokit, spies } = buildOctokit({
+      combinedState: 'success',
+      checkRuns: [
+        { name: 'slow-check', status: 'in_progress', conclusion: null },
+      ],
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result.status).toBe('blocked')
+    expect((result as { reason: string }).reason).toMatch(/slow-check/)
+    expect(spies.merge).not.toHaveBeenCalled()
+  })
+
+  it('blocks and comments when the merge API rejects with a conflict', async () => {
+    const { octokit, spies } = buildOctokit({
+      mergeError: { status: 409, message: 'Merge conflict' },
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result.status).toBe('blocked')
+    expect((result as { reason: string }).reason).toMatch(/409/)
+    expect((result as { reason: string }).reason).toMatch(/Merge conflict/)
+    expect(spies.addLabels).not.toHaveBeenCalled()
+    expect(spies.createComment).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks without calling merge when the PR has unresolved conflicts (mergeable=false)', async () => {
+    const { octokit, spies } = buildOctokit({
+      pull: { mergeable: false, mergeable_state: 'dirty' },
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result.status).toBe('blocked')
+    expect((result as { reason: string }).reason).toMatch(/dirty/)
+    expect(spies.merge).not.toHaveBeenCalled()
+    expect(spies.getCombinedStatusForRef).not.toHaveBeenCalled()
+  })
+
+  it('skips CI status checks when requireCiPass is false', async () => {
+    const { octokit, spies } = buildOctokit({
+      combinedState: 'failure',
+      mergeResponse: { sha: 'skip-ci-sha', merged: true },
+    })
+
+    const result = await autoMerge({
+      octokit,
+      ...baseInput,
+      requireCiPass: false,
+    })
+
+    expect(result).toEqual({ status: 'merged', sha: 'skip-ci-sha' })
+    expect(spies.getCombinedStatusForRef).not.toHaveBeenCalled()
+    expect(spies.listForRef).not.toHaveBeenCalled()
+    expect(spies.merge).toHaveBeenCalled()
+    expect(spies.addLabels).toHaveBeenCalled()
+  })
+
+  it('respects the configured merge strategy', async () => {
+    const { octokit, spies } = buildOctokit({})
+
+    await autoMerge({
+      octokit,
+      ...baseInput,
+      strategy: 'rebase',
+      requireCiPass: false,
+    })
+
+    expect(spies.merge).toHaveBeenCalledWith(
+      expect.objectContaining({ merge_method: 'rebase' }),
+    )
+  })
+
+  it('blocks when the PR is a draft', async () => {
+    const { octokit, spies } = buildOctokit({
+      pull: { draft: true },
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result.status).toBe('blocked')
+    expect((result as { reason: string }).reason).toMatch(/draft/)
+    expect(spies.merge).not.toHaveBeenCalled()
+  })
+})

--- a/packages/auto-merge/src/__tests__/auto-merge.test.ts
+++ b/packages/auto-merge/src/__tests__/auto-merge.test.ts
@@ -9,14 +9,21 @@ interface PullOverrides {
   sha?: string
 }
 
-function buildOctokit(opts: {
+type StatusEntry = { context: string; state: string }
+type CheckEntry = { name: string; status: string; conclusion: string | null }
+
+interface BuildOpts {
   pull?: PullOverrides
   combinedState?: 'success' | 'pending' | 'failure'
-  combinedStatuses?: Array<{ context: string; state: string }>
-  checkRuns?: Array<{ name: string; status: string; conclusion: string | null }>
+  combinedStatuses?: StatusEntry[]
+  combinedStatusPages?: StatusEntry[][]
+  checkRuns?: CheckEntry[]
+  checkRunPages?: CheckEntry[][]
   mergeResponse?: { sha: string; merged: boolean }
   mergeError?: { status?: number; message?: string }
-}) {
+}
+
+function buildOctokit(opts: BuildOpts) {
   const pull = {
     head: { sha: opts.pull?.sha ?? 'deadbeef' },
     state: opts.pull?.state ?? 'open',
@@ -25,15 +32,25 @@ function buildOctokit(opts: {
     draft: opts.pull?.draft ?? false,
   }
 
-  const getCombinedStatusForRef = vi.fn(async () => ({
-    data: {
-      state: opts.combinedState ?? 'success',
-      statuses: opts.combinedStatuses ?? [],
-    },
-  }))
-  const listForRef = vi.fn(async () => ({
-    data: { check_runs: opts.checkRuns ?? [] },
-  }))
+  const combinedPages: StatusEntry[][] =
+    opts.combinedStatusPages ?? [opts.combinedStatuses ?? []]
+  const overallState = opts.combinedState ?? 'success'
+
+  const getCombinedStatusForRef = vi.fn(async (params: { page?: number }) => {
+    const page = params.page ?? 1
+    const statuses = combinedPages[page - 1] ?? []
+    return { data: { state: overallState, statuses } }
+  })
+
+  const checkPages: CheckEntry[][] = opts.checkRunPages ?? [opts.checkRuns ?? []]
+  const totalCheckRuns = checkPages.reduce((n, p) => n + p.length, 0)
+
+  const listForRef = vi.fn(async (params: { page?: number }) => {
+    const page = params.page ?? 1
+    const check_runs = checkPages[page - 1] ?? []
+    return { data: { total_count: totalCheckRuns, check_runs } }
+  })
+
   const merge = vi.fn(async () => {
     if (opts.mergeError) {
       throw Object.assign(new Error(opts.mergeError.message ?? 'merge failed'), {
@@ -55,7 +72,17 @@ function buildOctokit(opts: {
     },
   }
 
-  return { octokit, spies: { get, merge, addLabels, createComment, getCombinedStatusForRef, listForRef } }
+  return {
+    octokit,
+    spies: {
+      get,
+      merge,
+      addLabels,
+      createComment,
+      getCombinedStatusForRef,
+      listForRef,
+    },
+  }
 }
 
 const baseInput = {
@@ -71,6 +98,7 @@ describe('autoMerge', () => {
   it('merges the PR and applies the auto-merged label when CI is green', async () => {
     const { octokit, spies } = buildOctokit({
       combinedState: 'success',
+      combinedStatuses: [{ context: 'lint', state: 'success' }],
       checkRuns: [{ name: 'ci', status: 'completed', conclusion: 'success' }],
       mergeResponse: { sha: 'final-sha', merged: true },
     })
@@ -118,6 +146,7 @@ describe('autoMerge', () => {
   it('blocks when a check run is still in progress', async () => {
     const { octokit, spies } = buildOctokit({
       combinedState: 'success',
+      combinedStatuses: [{ context: 'lint', state: 'success' }],
       checkRuns: [
         { name: 'slow-check', status: 'in_progress', conclusion: null },
       ],
@@ -132,6 +161,7 @@ describe('autoMerge', () => {
 
   it('blocks and comments when the merge API rejects with a conflict', async () => {
     const { octokit, spies } = buildOctokit({
+      combinedStatuses: [{ context: 'lint', state: 'success' }],
       mergeError: { status: 409, message: 'Merge conflict' },
     })
 
@@ -155,6 +185,20 @@ describe('autoMerge', () => {
     expect((result as { reason: string }).reason).toMatch(/dirty/)
     expect(spies.merge).not.toHaveBeenCalled()
     expect(spies.getCombinedStatusForRef).not.toHaveBeenCalled()
+  })
+
+  it('blocks without calling merge when GitHub has not finished computing mergeability (mergeable=null)', async () => {
+    const { octokit, spies } = buildOctokit({
+      pull: { mergeable: null, mergeable_state: 'unknown' },
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result.status).toBe('blocked')
+    expect((result as { reason: string }).reason).toMatch(/computed by GitHub/)
+    expect(spies.merge).not.toHaveBeenCalled()
+    expect(spies.getCombinedStatusForRef).not.toHaveBeenCalled()
+    expect(spies.createComment).toHaveBeenCalledTimes(1)
   })
 
   it('skips CI status checks when requireCiPass is false', async () => {
@@ -201,5 +245,71 @@ describe('autoMerge', () => {
     expect(result.status).toBe('blocked')
     expect((result as { reason: string }).reason).toMatch(/draft/)
     expect(spies.merge).not.toHaveBeenCalled()
+  })
+
+  it('blocks when no CI statuses and no check runs exist on the head SHA', async () => {
+    const { octokit, spies } = buildOctokit({
+      combinedState: 'pending',
+      combinedStatuses: [],
+      checkRuns: [],
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result.status).toBe('blocked')
+    expect((result as { reason: string }).reason).toMatch(/No CI statuses or check runs/)
+    expect(spies.merge).not.toHaveBeenCalled()
+    expect(spies.createComment).toHaveBeenCalledTimes(1)
+  })
+
+  it('detects a failing check run that sits on page 2 of the check-runs listing', async () => {
+    const firstPage: CheckEntry[] = Array.from({ length: 100 }, (_, i) => ({
+      name: `c${i}`,
+      status: 'completed',
+      conclusion: 'success',
+    }))
+    const secondPage: CheckEntry[] = [
+      { name: 'late-failure', status: 'completed', conclusion: 'failure' },
+    ]
+    const { octokit, spies } = buildOctokit({
+      combinedState: 'success',
+      combinedStatuses: [{ context: 'lint', state: 'success' }],
+      checkRunPages: [firstPage, secondPage],
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result.status).toBe('blocked')
+    expect((result as { reason: string }).reason).toMatch(/late-failure/)
+    expect(spies.listForRef).toHaveBeenCalledTimes(2)
+    expect(spies.listForRef.mock.calls[0][0]).toMatchObject({ page: 1, per_page: 100 })
+    expect(spies.listForRef.mock.calls[1][0]).toMatchObject({ page: 2, per_page: 100 })
+    expect(spies.merge).not.toHaveBeenCalled()
+  })
+
+  it('paginates combined statuses with per_page=100', async () => {
+    const firstPage: StatusEntry[] = Array.from({ length: 100 }, (_, i) => ({
+      context: `s${i}`,
+      state: 'success',
+    }))
+    const secondPage: StatusEntry[] = [{ context: 'final', state: 'success' }]
+    const { octokit, spies } = buildOctokit({
+      combinedState: 'success',
+      combinedStatusPages: [firstPage, secondPage],
+      checkRuns: [{ name: 'ci', status: 'completed', conclusion: 'success' }],
+    })
+
+    const result = await autoMerge({ octokit, ...baseInput })
+
+    expect(result.status).toBe('merged')
+    expect(spies.getCombinedStatusForRef).toHaveBeenCalledTimes(2)
+    expect(spies.getCombinedStatusForRef.mock.calls[0][0]).toMatchObject({
+      page: 1,
+      per_page: 100,
+    })
+    expect(spies.getCombinedStatusForRef.mock.calls[1][0]).toMatchObject({
+      page: 2,
+      per_page: 100,
+    })
   })
 })

--- a/packages/auto-merge/src/auto-merge.ts
+++ b/packages/auto-merge/src/auto-merge.ts
@@ -18,6 +18,8 @@ export interface OctokitLike {
         owner: string
         repo: string
         ref: string
+        per_page?: number
+        page?: number
       }): Promise<{ data: CombinedStatus }>
     }
     checks: {
@@ -25,6 +27,8 @@ export interface OctokitLike {
         owner: string
         repo: string
         ref: string
+        per_page?: number
+        page?: number
       }): Promise<{ data: CheckRunsResponse }>
     }
     issues: {
@@ -54,10 +58,12 @@ interface PullRequestData {
 
 interface CombinedStatus {
   state: 'success' | 'pending' | 'failure' | string
+  total_count?: number
   statuses: Array<{ context: string; state: string }>
 }
 
 interface CheckRunsResponse {
+  total_count: number
   check_runs: Array<{
     name: string
     status: string
@@ -80,6 +86,8 @@ export type AutoMergeResult =
   | { status: 'blocked'; reason: string }
 
 const COMMENT_MARKER = '<!-- harness[auto-merge] -->'
+const PER_PAGE = 100
+const PAGE_CAP = 20
 
 export async function autoMerge(input: AutoMergeInput): Promise<AutoMergeResult> {
   const { octokit, owner, repo, pullNumber, strategy, requireCiPass, autoMergedLabel } = input
@@ -95,6 +103,15 @@ export async function autoMerge(input: AutoMergeInput): Promise<AutoMergeResult>
   }
   if (pr.draft === true) {
     return blocked(octokit, owner, repo, pullNumber, 'PR is in draft state.')
+  }
+  if (pr.mergeable === null || pr.mergeable_state === 'unknown') {
+    return blocked(
+      octokit,
+      owner,
+      repo,
+      pullNumber,
+      `PR mergeability is still being computed by GitHub (mergeable=${pr.mergeable}, mergeable_state=${pr.mergeable_state}). Retry shortly.`,
+    )
   }
   if (pr.mergeable === false || pr.mergeable_state === 'dirty') {
     return blocked(
@@ -146,9 +163,9 @@ async function checkCiStatus(
   repo: string,
   sha: string,
 ): Promise<string | null> {
-  const [{ data: combined }, { data: checks }] = await Promise.all([
-    octokit.rest.repos.getCombinedStatusForRef({ owner, repo, ref: sha }),
-    octokit.rest.checks.listForRef({ owner, repo, ref: sha }),
+  const [combined, checkRuns] = await Promise.all([
+    fetchCombinedStatus(octokit, owner, repo, sha),
+    fetchAllCheckRuns(octokit, owner, repo, sha),
   ])
 
   if (combined.state === 'failure') {
@@ -161,11 +178,11 @@ async function checkCiStatus(
     return 'Combined CI status is still pending.'
   }
 
-  const unfinished = checks.check_runs.filter((c) => c.status !== 'completed')
+  const unfinished = checkRuns.filter((c) => c.status !== 'completed')
   if (unfinished.length > 0) {
     return `Check runs still in progress: ${unfinished.map((c) => c.name).join(', ')}.`
   }
-  const failed = checks.check_runs.filter(
+  const failed = checkRuns.filter(
     (c) =>
       c.conclusion !== null &&
       c.conclusion !== 'success' &&
@@ -176,7 +193,56 @@ async function checkCiStatus(
     return `Check runs failed: ${failed.map((c) => `${c.name} (${c.conclusion})`).join(', ')}.`
   }
 
+  if (combined.statuses.length === 0 && checkRuns.length === 0) {
+    return `No CI statuses or check runs observed on head SHA ${sha}. require-ci-pass=true requires at least one signal.`
+  }
+
   return null
+}
+
+async function fetchCombinedStatus(
+  octokit: OctokitLike,
+  owner: string,
+  repo: string,
+  sha: string,
+): Promise<CombinedStatus> {
+  let state: string | undefined
+  const statuses: Array<{ context: string; state: string }> = []
+  for (let page = 1; page <= PAGE_CAP; page++) {
+    const { data } = await octokit.rest.repos.getCombinedStatusForRef({
+      owner,
+      repo,
+      ref: sha,
+      per_page: PER_PAGE,
+      page,
+    })
+    state = data.state
+    statuses.push(...data.statuses)
+    if (data.statuses.length < PER_PAGE) break
+  }
+  return { state: state ?? 'pending', statuses }
+}
+
+async function fetchAllCheckRuns(
+  octokit: OctokitLike,
+  owner: string,
+  repo: string,
+  sha: string,
+): Promise<CheckRunsResponse['check_runs']> {
+  const all: CheckRunsResponse['check_runs'] = []
+  for (let page = 1; page <= PAGE_CAP; page++) {
+    const { data } = await octokit.rest.checks.listForRef({
+      owner,
+      repo,
+      ref: sha,
+      per_page: PER_PAGE,
+      page,
+    })
+    all.push(...data.check_runs)
+    if (data.check_runs.length < PER_PAGE) break
+    if (typeof data.total_count === 'number' && all.length >= data.total_count) break
+  }
+  return all
 }
 
 async function blocked(

--- a/packages/auto-merge/src/auto-merge.ts
+++ b/packages/auto-merge/src/auto-merge.ts
@@ -1,0 +1,207 @@
+export interface OctokitLike {
+  rest: {
+    pulls: {
+      get(params: {
+        owner: string
+        repo: string
+        pull_number: number
+      }): Promise<{ data: PullRequestData }>
+      merge(params: {
+        owner: string
+        repo: string
+        pull_number: number
+        merge_method: 'squash' | 'merge' | 'rebase'
+      }): Promise<{ data: { sha: string; merged: boolean } }>
+    }
+    repos: {
+      getCombinedStatusForRef(params: {
+        owner: string
+        repo: string
+        ref: string
+      }): Promise<{ data: CombinedStatus }>
+    }
+    checks: {
+      listForRef(params: {
+        owner: string
+        repo: string
+        ref: string
+      }): Promise<{ data: CheckRunsResponse }>
+    }
+    issues: {
+      addLabels(params: {
+        owner: string
+        repo: string
+        issue_number: number
+        labels: string[]
+      }): Promise<unknown>
+      createComment(params: {
+        owner: string
+        repo: string
+        issue_number: number
+        body: string
+      }): Promise<unknown>
+    }
+  }
+}
+
+interface PullRequestData {
+  head: { sha: string }
+  mergeable: boolean | null
+  mergeable_state: string
+  state: string
+  draft?: boolean
+}
+
+interface CombinedStatus {
+  state: 'success' | 'pending' | 'failure' | string
+  statuses: Array<{ context: string; state: string }>
+}
+
+interface CheckRunsResponse {
+  check_runs: Array<{
+    name: string
+    status: string
+    conclusion: string | null
+  }>
+}
+
+export interface AutoMergeInput {
+  octokit: OctokitLike
+  owner: string
+  repo: string
+  pullNumber: number
+  strategy: 'squash' | 'merge' | 'rebase'
+  requireCiPass: boolean
+  autoMergedLabel: string
+}
+
+export type AutoMergeResult =
+  | { status: 'merged'; sha: string }
+  | { status: 'blocked'; reason: string }
+
+const COMMENT_MARKER = '<!-- harness[auto-merge] -->'
+
+export async function autoMerge(input: AutoMergeInput): Promise<AutoMergeResult> {
+  const { octokit, owner, repo, pullNumber, strategy, requireCiPass, autoMergedLabel } = input
+
+  const { data: pr } = await octokit.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  })
+
+  if (pr.state !== 'open') {
+    return blocked(octokit, owner, repo, pullNumber, `PR is not open (state=${pr.state}).`)
+  }
+  if (pr.draft === true) {
+    return blocked(octokit, owner, repo, pullNumber, 'PR is in draft state.')
+  }
+  if (pr.mergeable === false || pr.mergeable_state === 'dirty') {
+    return blocked(
+      octokit,
+      owner,
+      repo,
+      pullNumber,
+      `PR has merge conflicts (mergeable_state=${pr.mergeable_state}).`,
+    )
+  }
+
+  if (requireCiPass) {
+    const ciFailure = await checkCiStatus(octokit, owner, repo, pr.head.sha)
+    if (ciFailure) {
+      return blocked(octokit, owner, repo, pullNumber, ciFailure)
+    }
+  }
+
+  let mergeSha: string
+  try {
+    const { data } = await octokit.rest.pulls.merge({
+      owner,
+      repo,
+      pull_number: pullNumber,
+      merge_method: strategy,
+    })
+    if (!data.merged) {
+      return blocked(octokit, owner, repo, pullNumber, 'GitHub reported merge=false without error.')
+    }
+    mergeSha = data.sha
+  } catch (err) {
+    const msg = formatMergeError(err)
+    return blocked(octokit, owner, repo, pullNumber, `Merge API rejected: ${msg}`)
+  }
+
+  await octokit.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: pullNumber,
+    labels: [autoMergedLabel],
+  })
+
+  return { status: 'merged', sha: mergeSha }
+}
+
+async function checkCiStatus(
+  octokit: OctokitLike,
+  owner: string,
+  repo: string,
+  sha: string,
+): Promise<string | null> {
+  const [{ data: combined }, { data: checks }] = await Promise.all([
+    octokit.rest.repos.getCombinedStatusForRef({ owner, repo, ref: sha }),
+    octokit.rest.checks.listForRef({ owner, repo, ref: sha }),
+  ])
+
+  if (combined.state === 'failure') {
+    const failing = combined.statuses
+      .filter((s) => s.state === 'failure' || s.state === 'error')
+      .map((s) => s.context)
+    return `Combined CI status is failing (${failing.join(', ') || 'unknown contexts'}).`
+  }
+  if (combined.state === 'pending' && combined.statuses.length > 0) {
+    return 'Combined CI status is still pending.'
+  }
+
+  const unfinished = checks.check_runs.filter((c) => c.status !== 'completed')
+  if (unfinished.length > 0) {
+    return `Check runs still in progress: ${unfinished.map((c) => c.name).join(', ')}.`
+  }
+  const failed = checks.check_runs.filter(
+    (c) =>
+      c.conclusion !== null &&
+      c.conclusion !== 'success' &&
+      c.conclusion !== 'skipped' &&
+      c.conclusion !== 'neutral',
+  )
+  if (failed.length > 0) {
+    return `Check runs failed: ${failed.map((c) => `${c.name} (${c.conclusion})`).join(', ')}.`
+  }
+
+  return null
+}
+
+async function blocked(
+  octokit: OctokitLike,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  reason: string,
+): Promise<AutoMergeResult> {
+  const body = `${COMMENT_MARKER}\n:robot: **harness auto-merge blocked.**\n\n${reason}`
+  await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pullNumber,
+    body,
+  })
+  return { status: 'blocked', reason }
+}
+
+function formatMergeError(err: unknown): string {
+  if (typeof err === 'object' && err !== null) {
+    const e = err as { status?: number; message?: string }
+    const status = e.status !== undefined ? `${e.status} ` : ''
+    const message = e.message ?? String(err)
+    return `${status}${message}`.trim()
+  }
+  return String(err)
+}

--- a/packages/auto-merge/src/index.ts
+++ b/packages/auto-merge/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  autoMerge,
+  type AutoMergeInput,
+  type AutoMergeResult,
+  type OctokitLike,
+} from './auto-merge.js'

--- a/packages/auto-merge/src/run.ts
+++ b/packages/auto-merge/src/run.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs'
+import { autoMerge } from './auto-merge.js'
+
+interface WorkflowEventPayload {
+  pull_request?: { number: number }
+  number?: number
+}
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value || value.trim() === '') {
+    throw new Error(`${name} is required`)
+  }
+  return value
+}
+
+function parseStrategy(raw: string | undefined): 'squash' | 'merge' | 'rebase' {
+  const value = (raw ?? 'squash').trim().toLowerCase()
+  if (value === 'squash' || value === 'merge' || value === 'rebase') return value
+  throw new Error(`invalid strategy: ${raw} (expected squash|merge|rebase)`)
+}
+
+function parseBool(raw: string | undefined, fallback: boolean): boolean {
+  if (raw === undefined) return fallback
+  const v = raw.trim().toLowerCase()
+  if (v === 'true' || v === '1' || v === 'yes') return true
+  if (v === 'false' || v === '0' || v === 'no' || v === '') return false
+  throw new Error(`invalid boolean: ${raw}`)
+}
+
+function resolvePullNumber(): number {
+  const explicit = process.env.INPUT_PULL_NUMBER
+  if (explicit) {
+    const n = Number.parseInt(explicit, 10)
+    if (!Number.isInteger(n) || n <= 0) throw new Error(`invalid INPUT_PULL_NUMBER: ${explicit}`)
+    return n
+  }
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is not set')
+  const payload = JSON.parse(readFileSync(eventPath, 'utf8')) as WorkflowEventPayload
+  const num = payload.pull_request?.number ?? payload.number
+  if (typeof num !== 'number') throw new Error('event payload has no pull_request.number')
+  return num
+}
+
+async function main(): Promise<void> {
+  const token = required('INPUT_GITHUB_TOKEN')
+  const strategy = parseStrategy(process.env.INPUT_STRATEGY)
+  const requireCiPass = parseBool(process.env.INPUT_REQUIRE_CI_PASS, true)
+  const autoMergedLabel = process.env.INPUT_AUTO_MERGED_LABEL?.trim() || 'harness:auto-merged'
+
+  const repoSlug = required('GITHUB_REPOSITORY')
+  const [owner, repo] = repoSlug.split('/')
+  if (!owner || !repo) throw new Error(`invalid GITHUB_REPOSITORY: ${repoSlug}`)
+
+  const pullNumber = resolvePullNumber()
+
+  const { Octokit } = await import('@octokit/rest')
+  const octokit = new Octokit({ auth: token })
+
+  const result = await autoMerge({
+    octokit,
+    owner,
+    repo,
+    pullNumber,
+    strategy,
+    requireCiPass,
+    autoMergedLabel,
+  })
+
+  if (result.status === 'merged') {
+    console.log(`auto-merge: merged ${owner}/${repo}#${pullNumber} (sha=${result.sha})`)
+    return
+  }
+  console.error(`auto-merge: blocked — ${result.reason}`)
+  process.exit(1)
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.stack ?? err.message : String(err))
+  process.exit(1)
+})

--- a/packages/auto-merge/tsconfig.json
+++ b/packages/auto-merge/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "**/__tests__/**"]
 }

--- a/packages/auto-merge/tsconfig.json
+++ b/packages/auto-merge/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/auto-merge/tsup.config.ts
+++ b/packages/auto-merge/tsup.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    target: 'node20',
+  },
+  {
+    entry: ['src/run.ts'],
+    format: ['esm'],
+    dts: false,
+    clean: false,
+    sourcemap: true,
+    target: 'node20',
+    banner: {
+      js: '#!/usr/bin/env node',
+    },
+  },
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,25 @@ importers:
         specifier: ^5.6.3
         version: 5.9.3
 
+  packages/auto-merge:
+    dependencies:
+      '@octokit/rest':
+        specifier: ^21.0.2
+        version: 21.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.3
+        version: 22.19.17
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.5
+        version: 2.1.9(@types/node@22.19.17)
+
   packages/classifier:
     dependencies:
       '@butaosuinu/harness-shared':


### PR DESCRIPTION
## Summary
- New workspace package `@butaosuinu/harness-auto-merge` exposing a pure `autoMerge(...)` function (octokit injected) plus a `run.ts` GHA entry.
- `actions/auto-merge/action.yml` composite action wired to `npx @butaosuinu/harness-auto-merge`. Inputs: `github-token`, `strategy` (default `squash`), `require-ci-pass` (default `true`), `auto-merged-label` (default `harness:auto-merged`).
- Applies the `harness:auto-merged` label on success. On conflict / CI failure / draft / non-open state, posts a PR comment marked `<!-- harness[auto-merge] -->` and fails the action.

## Test plan
- [x] `pnpm --filter @butaosuinu/harness-auto-merge test` — 8 cases (merge success, combined status failure, pending check run, 409 merge conflict, dirty mergeable_state, draft PR, skip-CI path, rebase strategy).
- [x] `pnpm -r build`
- [x] `pnpm -r test`
- [x] `pnpm -r test:types`
- [ ] End-to-end GHA invocation is out of scope here; will be exercised by #11 (`harness-check.yml`).

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)