### PR TITLE
feat(cli): classify に PR label / comment / step summary / reviewer を追加

### DIFF
--- a/packages/cli/src/__tests__/classify-github.test.ts
+++ b/packages/cli/src/__tests__/classify-github.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Command } from 'commander'
+import { registerClassifyCommand } from '../commands/classify.js'
+import type { OctokitLike } from '../github.js'
+
+const configYaml = `
+harness:
+  version: "1"
+  risk_rules:
+    high:
+      file_patterns:
+        - "prisma/schema.prisma"
+    low:
+      file_patterns:
+        - "**/*.md"
+  auto_merge:
+    labels:
+      high_risk: "harness:high-risk"
+      low_risk: "harness:low-risk"
+`
+
+function makeOctokit(listFilesResponse: unknown[], listCommentsResponse: unknown[] = []) {
+  const paginate = vi.fn(async (fn: unknown) => {
+    if (fn === octokit.rest.pulls.listFiles) return listFilesResponse
+    if (fn === octokit.rest.issues.listComments) return listCommentsResponse
+    return []
+  })
+  const octokit: OctokitLike & {
+    paginate: ReturnType<typeof vi.fn>
+    rest: {
+      pulls: {
+        listFiles: unknown
+        requestReviewers: ReturnType<typeof vi.fn>
+      }
+      issues: {
+        addLabels: ReturnType<typeof vi.fn>
+        removeLabel: ReturnType<typeof vi.fn>
+        listComments: unknown
+        createComment: ReturnType<typeof vi.fn>
+        updateComment: ReturnType<typeof vi.fn>
+      }
+    }
+  } = {
+    paginate,
+    rest: {
+      pulls: {
+        listFiles: { marker: 'listFiles' },
+        requestReviewers: vi.fn().mockResolvedValue({}),
+      },
+      issues: {
+        addLabels: vi.fn().mockResolvedValue({}),
+        removeLabel: vi.fn().mockRejectedValue(
+          Object.assign(new Error('Not Found'), { status: 404 }),
+        ),
+        listComments: { marker: 'listComments' },
+        createComment: vi.fn().mockResolvedValue({}),
+        updateComment: vi.fn().mockResolvedValue({}),
+      },
+    },
+  }
+  return octokit
+}
+
+let tmpDir: string
+let summaryFile: string
+let eventFile: string
+const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'harness-classify-gh-'))
+  mkdirSync(join(tmpDir, '.harness'))
+  writeFileSync(join(tmpDir, '.harness', 'config.yml'), configYaml, 'utf8')
+  eventFile = join(tmpDir, 'event.json')
+  writeFileSync(
+    eventFile,
+    JSON.stringify({ pull_request: { number: 7 } }),
+    'utf8',
+  )
+  summaryFile = join(tmpDir, 'step-summary.md')
+  stdoutSpy.mockClear()
+})
+
+afterEach(() => {
+  try {
+    rmSync(tmpDir, { recursive: true, force: true })
+  } catch {}
+})
+
+function env(): NodeJS.ProcessEnv {
+  return {
+    GITHUB_REPOSITORY: 'acme/app',
+    GITHUB_EVENT_PATH: eventFile,
+    GITHUB_STEP_SUMMARY: summaryFile,
+  } as NodeJS.ProcessEnv
+}
+
+async function runClassify(
+  octokit: OctokitLike,
+  extraArgs: string[] = [],
+  envOverrides: NodeJS.ProcessEnv = env(),
+): Promise<void> {
+  const program = new Command()
+  program.exitOverride()
+  registerClassifyCommand(program, {
+    octokitFactory: async () => octokit,
+    env: envOverrides,
+  })
+  await program.parseAsync(
+    [
+      'classify',
+      '--github-token',
+      'fake',
+      '--output',
+      'json',
+      '--cwd',
+      tmpDir,
+      ...extraArgs,
+    ],
+    { from: 'user' },
+  )
+}
+
+describe('classify command — GitHub integration', () => {
+  it('applies high-risk label, posts new comment, requests codeowner reviewers on high risk', async () => {
+    writeFileSync(
+      join(tmpDir, 'CODEOWNERS'),
+      'prisma/** @acme/db @alice\n',
+      'utf8',
+    )
+    const octokit = makeOctokit([
+      {
+        filename: 'prisma/schema.prisma',
+        status: 'modified',
+        additions: 5,
+        deletions: 1,
+        patch: '@@\n+model User {}\n',
+      },
+    ])
+    await runClassify(octokit)
+
+    expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'app',
+      issue_number: 7,
+      labels: ['harness:high-risk'],
+    })
+    expect(octokit.rest.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'harness:low-risk' }),
+    )
+    expect(octokit.rest.issues.createComment).toHaveBeenCalledTimes(1)
+    const commentCall = octokit.rest.issues.createComment.mock.calls[0]![0] as {
+      body: string
+    }
+    expect(commentCall.body).toContain('<!-- harness[classify] -->')
+    expect(commentCall.body).toContain('HIGH')
+
+    expect(octokit.rest.pulls.requestReviewers).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'app',
+      pull_number: 7,
+      reviewers: ['alice'],
+      team_reviewers: ['db'],
+    })
+
+    const summary = readFileSync(summaryFile, 'utf8')
+    expect(summary).toContain('## Harness classify')
+    expect(summary).toContain('HIGH')
+  })
+
+  it('applies low-risk label and skips reviewer request on low risk', async () => {
+    const octokit = makeOctokit([
+      {
+        filename: 'README.md',
+        status: 'modified',
+        additions: 1,
+        deletions: 0,
+        patch: '',
+      },
+    ])
+    await runClassify(octokit)
+
+    expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: ['harness:low-risk'] }),
+    )
+    expect(octokit.rest.pulls.requestReviewers).not.toHaveBeenCalled()
+  })
+
+  it('updates an existing marker comment instead of creating a new one', async () => {
+    const octokit = makeOctokit(
+      [
+        {
+          filename: 'prisma/schema.prisma',
+          status: 'modified',
+          additions: 1,
+          deletions: 0,
+        },
+      ],
+      [
+        { id: 11, body: 'old unrelated' },
+        { id: 99, body: '<!-- harness[classify] -->\nprevious run' },
+      ],
+    )
+    await runClassify(octokit)
+    expect(octokit.rest.issues.updateComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 99 }),
+    )
+    expect(octokit.rest.issues.createComment).not.toHaveBeenCalled()
+  })
+
+  it('respects --no-labels and --no-post-comment', async () => {
+    const octokit = makeOctokit([
+      {
+        filename: 'prisma/schema.prisma',
+        status: 'modified',
+        additions: 1,
+        deletions: 0,
+      },
+    ])
+    await runClassify(octokit, ['--no-labels', '--no-post-comment'])
+    expect(octokit.rest.issues.addLabels).not.toHaveBeenCalled()
+    expect(octokit.rest.issues.removeLabel).not.toHaveBeenCalled()
+    expect(octokit.rest.issues.createComment).not.toHaveBeenCalled()
+    expect(octokit.rest.issues.updateComment).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/__tests__/codeowners.test.ts
+++ b/packages/cli/src/__tests__/codeowners.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectReviewersForFiles,
+  ownersForFile,
+  ownersToReviewerGroups,
+  parseCodeowners,
+} from '../codeowners.js'
+
+describe('parseCodeowners', () => {
+  it('ignores blank lines and comments', () => {
+    const rules = parseCodeowners(`
+# top-level comment
+*.js @frontend
+
+# next rule
+/infra/ @ops-team
+    `)
+    expect(rules.map((r) => r.pattern)).toEqual(['*.js', '/infra/'])
+    expect(rules[0]!.owners).toEqual(['@frontend'])
+    expect(rules[1]!.owners).toEqual(['@ops-team'])
+  })
+
+  it('strips inline comments', () => {
+    const rules = parseCodeowners(`*.ts @ts-team # default owners`)
+    expect(rules).toHaveLength(1)
+    expect(rules[0]!.owners).toEqual(['@ts-team'])
+  })
+
+  it('supports multiple owners', () => {
+    const rules = parseCodeowners(`prisma/** @org/db @alice`)
+    expect(rules[0]!.owners).toEqual(['@org/db', '@alice'])
+  })
+})
+
+describe('ownersForFile', () => {
+  it('matches unanchored globs at any depth', () => {
+    const rules = parseCodeowners(`*.md @docs`)
+    expect(ownersForFile(rules, 'README.md')).toEqual(['@docs'])
+    expect(ownersForFile(rules, 'packages/foo/CHANGES.md')).toEqual(['@docs'])
+    expect(ownersForFile(rules, 'src/x.ts')).toEqual([])
+  })
+
+  it('matches anchored patterns from repo root only', () => {
+    const rules = parseCodeowners(`/docs/*.md @docs`)
+    expect(ownersForFile(rules, 'docs/readme.md')).toEqual(['@docs'])
+    expect(ownersForFile(rules, 'apps/docs/readme.md')).toEqual([])
+  })
+
+  it('matches trailing-slash patterns against any file under that dir', () => {
+    const rules = parseCodeowners(`/infra/ @ops`)
+    expect(ownersForFile(rules, 'infra/terraform/main.tf')).toEqual(['@ops'])
+    expect(ownersForFile(rules, 'infra/README.md')).toEqual(['@ops'])
+  })
+
+  it('matches ** to any depth', () => {
+    const rules = parseCodeowners(`**/migrations/** @db`)
+    expect(ownersForFile(rules, 'apps/api/migrations/001.sql')).toEqual(['@db'])
+    expect(ownersForFile(rules, 'migrations/x.sql')).toEqual(['@db'])
+  })
+
+  it('last matching rule wins', () => {
+    const rules = parseCodeowners(`
+*.ts @global
+packages/cli/** @cli-team
+    `)
+    expect(ownersForFile(rules, 'packages/cli/src/index.ts')).toEqual([
+      '@cli-team',
+    ])
+    expect(ownersForFile(rules, 'packages/shared/src/index.ts')).toEqual([
+      '@global',
+    ])
+  })
+})
+
+describe('ownersToReviewerGroups', () => {
+  it('separates users, teams, and discards emails', () => {
+    const groups = ownersToReviewerGroups([
+      '@alice',
+      '@bob',
+      '@my-org/frontend',
+      '@my-org/backend',
+      'someone@example.com',
+      '@alice',
+    ])
+    expect(groups.users.sort()).toEqual(['alice', 'bob'])
+    expect(groups.teams.sort()).toEqual(['backend', 'frontend'])
+  })
+})
+
+describe('collectReviewersForFiles', () => {
+  it('unions owners across all changed files', () => {
+    const rules = parseCodeowners(`
+*.ts @ts-team
+prisma/** @org/db
+    `)
+    const groups = collectReviewersForFiles(rules, [
+      'src/a.ts',
+      'prisma/schema.prisma',
+    ])
+    expect(groups.users).toEqual(['ts-team'])
+    expect(groups.teams).toEqual(['db'])
+  })
+})

--- a/packages/cli/src/__tests__/github.test.ts
+++ b/packages/cli/src/__tests__/github.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyLabels,
+  CLASSIFY_COMMENT_MARKER,
+  requestCodeownerReviewers,
+  resolvePullRequestContext,
+  upsertMatchedReasonComment,
+  type OctokitLike,
+  type PullRequestContext,
+} from '../github.js'
+
+function makeOctokit(): OctokitLike & {
+  paginate: ReturnType<typeof vi.fn>
+  rest: {
+    pulls: {
+      listFiles: unknown
+      requestReviewers: ReturnType<typeof vi.fn>
+    }
+    issues: {
+      addLabels: ReturnType<typeof vi.fn>
+      removeLabel: ReturnType<typeof vi.fn>
+      listComments: unknown
+      createComment: ReturnType<typeof vi.fn>
+      updateComment: ReturnType<typeof vi.fn>
+    }
+  }
+} {
+  return {
+    paginate: vi.fn().mockResolvedValue([]),
+    rest: {
+      pulls: {
+        listFiles: vi.fn(),
+        requestReviewers: vi.fn().mockResolvedValue({}),
+      },
+      issues: {
+        addLabels: vi.fn().mockResolvedValue({}),
+        removeLabel: vi.fn().mockResolvedValue({}),
+        listComments: vi.fn(),
+        createComment: vi.fn().mockResolvedValue({}),
+        updateComment: vi.fn().mockResolvedValue({}),
+      },
+    },
+  }
+}
+
+const ctx: PullRequestContext = { owner: 'foo', repo: 'bar', prNumber: 42 }
+
+describe('resolvePullRequestContext', () => {
+  it('extracts owner, repo, and prNumber from env + event file', () => {
+    const env = {
+      GITHUB_REPOSITORY: 'foo/bar',
+      GITHUB_EVENT_PATH: '/tmp/event.json',
+    } as NodeJS.ProcessEnv
+    const readFileSync = vi.fn(
+      () => JSON.stringify({ pull_request: { number: 42 } }),
+    )
+    const result = resolvePullRequestContext(env, readFileSync)
+    expect(result).toEqual({ owner: 'foo', repo: 'bar', prNumber: 42 })
+  })
+
+  it('throws when GITHUB_REPOSITORY is missing', () => {
+    expect(() =>
+      resolvePullRequestContext({} as NodeJS.ProcessEnv, () => ''),
+    ).toThrow(/GITHUB_REPOSITORY/)
+  })
+
+  it('throws when event payload has no pull_request.number', () => {
+    const env = {
+      GITHUB_REPOSITORY: 'a/b',
+      GITHUB_EVENT_PATH: '/tmp/e.json',
+    } as NodeJS.ProcessEnv
+    expect(() =>
+      resolvePullRequestContext(env, () => JSON.stringify({})),
+    ).toThrow(/pull_request/)
+  })
+})
+
+describe('applyLabels', () => {
+  const cfg = { highRiskLabel: 'harness:high-risk', lowRiskLabel: 'harness:low-risk' }
+
+  it('adds high label and removes low label on high risk', async () => {
+    const octokit = makeOctokit()
+    await applyLabels(octokit, ctx, cfg, 'high')
+    expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith({
+      owner: 'foo',
+      repo: 'bar',
+      issue_number: 42,
+      labels: ['harness:high-risk'],
+    })
+    expect(octokit.rest.issues.removeLabel).toHaveBeenCalledWith({
+      owner: 'foo',
+      repo: 'bar',
+      issue_number: 42,
+      name: 'harness:low-risk',
+    })
+  })
+
+  it('adds low label and removes high label on low risk', async () => {
+    const octokit = makeOctokit()
+    await applyLabels(octokit, ctx, cfg, 'low')
+    expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: ['harness:low-risk'] }),
+    )
+    expect(octokit.rest.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'harness:high-risk' }),
+    )
+  })
+
+  it('swallows 404 when removing a label that is not present', async () => {
+    const octokit = makeOctokit()
+    const notFound = Object.assign(new Error('Not Found'), { status: 404 })
+    octokit.rest.issues.removeLabel.mockRejectedValueOnce(notFound)
+    await expect(applyLabels(octokit, ctx, cfg, 'high')).resolves.toBeUndefined()
+  })
+
+  it('re-throws non-404 errors on removeLabel', async () => {
+    const octokit = makeOctokit()
+    const boom = Object.assign(new Error('Server error'), { status: 500 })
+    octokit.rest.issues.removeLabel.mockRejectedValueOnce(boom)
+    await expect(applyLabels(octokit, ctx, cfg, 'high')).rejects.toThrow(
+      /Server error/,
+    )
+  })
+})
+
+describe('upsertMatchedReasonComment', () => {
+  it('creates a new comment when none has the marker', async () => {
+    const octokit = makeOctokit()
+    octokit.paginate.mockResolvedValueOnce([
+      { id: 1, body: 'unrelated comment' },
+    ])
+    await upsertMatchedReasonComment(octokit, ctx, 'hello')
+    expect(octokit.rest.issues.createComment).toHaveBeenCalledWith({
+      owner: 'foo',
+      repo: 'bar',
+      issue_number: 42,
+      body: 'hello',
+    })
+    expect(octokit.rest.issues.updateComment).not.toHaveBeenCalled()
+  })
+
+  it('updates the existing marker comment', async () => {
+    const octokit = makeOctokit()
+    octokit.paginate.mockResolvedValueOnce([
+      { id: 100, body: 'something' },
+      { id: 200, body: `${CLASSIFY_COMMENT_MARKER}\nprevious body` },
+    ])
+    await upsertMatchedReasonComment(octokit, ctx, 'updated body')
+    expect(octokit.rest.issues.updateComment).toHaveBeenCalledWith({
+      owner: 'foo',
+      repo: 'bar',
+      comment_id: 200,
+      body: 'updated body',
+    })
+    expect(octokit.rest.issues.createComment).not.toHaveBeenCalled()
+  })
+})
+
+describe('requestCodeownerReviewers', () => {
+  it('sends deduped users and teams', async () => {
+    const octokit = makeOctokit()
+    await requestCodeownerReviewers(octokit, ctx, {
+      users: ['alice', 'bob', 'alice'],
+      teams: ['frontend', 'frontend'],
+    })
+    expect(octokit.rest.pulls.requestReviewers).toHaveBeenCalledWith({
+      owner: 'foo',
+      repo: 'bar',
+      pull_number: 42,
+      reviewers: ['alice', 'bob'],
+      team_reviewers: ['frontend'],
+    })
+  })
+
+  it('omits empty reviewer arrays', async () => {
+    const octokit = makeOctokit()
+    await requestCodeownerReviewers(octokit, ctx, {
+      users: [],
+      teams: ['ops'],
+    })
+    const call = octokit.rest.pulls.requestReviewers.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >
+    expect(call.reviewers).toBeUndefined()
+    expect(call.team_reviewers).toEqual(['ops'])
+  })
+
+  it('skips the API call when there are no reviewers at all', async () => {
+    const octokit = makeOctokit()
+    await requestCodeownerReviewers(octokit, ctx, { users: [], teams: [] })
+    expect(octokit.rest.pulls.requestReviewers).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/__tests__/step-summary.test.ts
+++ b/packages/cli/src/__tests__/step-summary.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ClassifyResult } from '@butaosuinu/harness-shared'
+import { renderStepSummary, writeStepSummary } from '../step-summary.js'
+
+const highRiskResult: ClassifyResult = {
+  riskLevel: 'high',
+  summary: 'migration files touched',
+  matchedRules: [
+    {
+      ruleId: 'prisma-schema',
+      ruleType: 'file_pattern',
+      description: 'Prisma schema changed',
+      matches: [{ file: 'prisma/schema.prisma' }],
+    },
+  ],
+}
+
+describe('renderStepSummary', () => {
+  it('includes risk level, summary, and rules', () => {
+    const md = renderStepSummary(highRiskResult)
+    expect(md).toContain('## Harness classify')
+    expect(md).toContain('**Risk level:** `HIGH`')
+    expect(md).toContain('**Summary:** migration files touched')
+    expect(md).toContain('### Matched rules')
+    expect(md).toContain('prisma-schema')
+    expect(md).toContain('prisma/schema.prisma')
+  })
+
+  it('truncates matches beyond 5 per rule', () => {
+    const many: ClassifyResult = {
+      riskLevel: 'low',
+      summary: 'big',
+      matchedRules: [
+        {
+          ruleId: 'r',
+          ruleType: 'diff_size',
+          description: 'too many files',
+          matches: Array.from({ length: 9 }, (_, i) => ({
+            file: `f${i}.ts`,
+          })),
+        },
+      ],
+    }
+    const md = renderStepSummary(many)
+    expect(md).toContain('(+4 more)')
+  })
+})
+
+describe('writeStepSummary', () => {
+  it('appends rendered markdown when GITHUB_STEP_SUMMARY is set', () => {
+    const append = vi.fn()
+    writeStepSummary(
+      highRiskResult,
+      { GITHUB_STEP_SUMMARY: '/tmp/summary.md' } as NodeJS.ProcessEnv,
+      append,
+    )
+    expect(append).toHaveBeenCalledTimes(1)
+    const [path, data] = append.mock.calls[0]!
+    expect(path).toBe('/tmp/summary.md')
+    expect(data).toContain('## Harness classify')
+    expect(data.endsWith('\n')).toBe(true)
+  })
+
+  it('no-ops when GITHUB_STEP_SUMMARY is unset', () => {
+    const append = vi.fn()
+    writeStepSummary(highRiskResult, {} as NodeJS.ProcessEnv, append)
+    expect(append).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when GITHUB_STEP_SUMMARY is empty', () => {
+    const append = vi.fn()
+    writeStepSummary(
+      highRiskResult,
+      { GITHUB_STEP_SUMMARY: '   ' } as NodeJS.ProcessEnv,
+      append,
+    )
+    expect(append).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/codeowners.ts
+++ b/packages/cli/src/codeowners.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface CodeownersRule {
+  pattern: string
+  regex: RegExp
+  owners: string[]
+}
+
+const CANDIDATE_PATHS = ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS']
+
+export function findCodeownersFile(cwd: string): string | null {
+  for (const rel of CANDIDATE_PATHS) {
+    const p = join(cwd, rel)
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+export function loadCodeowners(cwd: string): CodeownersRule[] {
+  const path = findCodeownersFile(cwd)
+  if (!path) return []
+  return parseCodeowners(readFileSync(path, 'utf8'))
+}
+
+export function parseCodeowners(contents: string): CodeownersRule[] {
+  const rules: CodeownersRule[] = []
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = stripComment(rawLine).trim()
+    if (line === '') continue
+    const tokens = line.split(/\s+/)
+    const pattern = tokens[0]
+    if (!pattern) continue
+    const owners = tokens.slice(1).filter((t) => t !== '')
+    rules.push({ pattern, regex: patternToRegex(pattern), owners })
+  }
+  return rules
+}
+
+export function ownersForFile(
+  rules: CodeownersRule[],
+  filename: string,
+): string[] {
+  const normalized = filename.replace(/^\.\//, '').replace(/^\//, '')
+  for (let i = rules.length - 1; i >= 0; i--) {
+    const rule = rules[i]!
+    if (rule.regex.test(normalized)) return rule.owners
+  }
+  return []
+}
+
+export interface ReviewerGroups {
+  users: string[]
+  teams: string[]
+}
+
+export function ownersToReviewerGroups(owners: string[]): ReviewerGroups {
+  const users = new Set<string>()
+  const teams = new Set<string>()
+  for (const owner of owners) {
+    if (!owner.startsWith('@')) continue
+    const body = owner.slice(1)
+    if (body.includes('/')) {
+      const [, team] = body.split('/', 2)
+      if (team) teams.add(team)
+    } else if (body !== '') {
+      users.add(body)
+    }
+  }
+  return { users: [...users], teams: [...teams] }
+}
+
+export function collectReviewersForFiles(
+  rules: CodeownersRule[],
+  filenames: string[],
+): ReviewerGroups {
+  const owners = new Set<string>()
+  for (const f of filenames) {
+    for (const o of ownersForFile(rules, f)) owners.add(o)
+  }
+  return ownersToReviewerGroups([...owners])
+}
+
+function stripComment(line: string): string {
+  const idx = line.indexOf('#')
+  return idx === -1 ? line : line.slice(0, idx)
+}
+
+const TOKEN_GSTAR_SLASH = '\x01'
+const TOKEN_SLASH_GSTAR = '\x02'
+const TOKEN_GSTAR = '\x03'
+const TOKEN_STAR = '\x04'
+const TOKEN_QMARK = '\x05'
+
+function patternToRegex(pattern: string): RegExp {
+  let p = pattern
+  const anchored = p.startsWith('/')
+  if (anchored) p = p.slice(1)
+  if (p.endsWith('/')) p = `${p}**`
+
+  p = p
+    .replace(/\*\*\//g, TOKEN_GSTAR_SLASH)
+    .replace(/\/\*\*/g, TOKEN_SLASH_GSTAR)
+    .replace(/\*\*/g, TOKEN_GSTAR)
+    .replace(/\*/g, TOKEN_STAR)
+    .replace(/\?/g, TOKEN_QMARK)
+    .replace(/[.+^$()|{}[\]\\]/g, '\\$&')
+    .replaceAll(TOKEN_GSTAR_SLASH, '(?:.*\\/)?')
+    .replaceAll(TOKEN_SLASH_GSTAR, '(?:\\/.*)?')
+    .replaceAll(TOKEN_GSTAR, '.*')
+    .replaceAll(TOKEN_STAR, '[^/]*')
+    .replaceAll(TOKEN_QMARK, '[^/]')
+
+  return new RegExp(anchored ? `^${p}$` : `(?:^|/)${p}$`)
+}

--- a/packages/cli/src/commands/classify.ts
+++ b/packages/cli/src/commands/classify.ts
@@ -1,15 +1,30 @@
 import { execFileSync } from 'node:child_process'
-import { readFile, readFileSync } from 'node:fs'
+import { readFile } from 'node:fs'
 import { promisify } from 'node:util'
 import { join, resolve } from 'node:path'
 import type { Command } from 'commander'
 import jsYaml from 'js-yaml'
 import {
   HarnessConfigSchema,
+  type ClassifyResult,
   type DiffFile,
+  type HarnessConfig,
 } from '@butaosuinu/harness-shared'
 import { classify, parseUnifiedDiff } from '@butaosuinu/harness-classifier'
 import { ZodError } from 'zod'
+import {
+  applyLabels,
+  CLASSIFY_COMMENT_MARKER,
+  defaultOctokitFactory,
+  type OctokitFactory,
+  type OctokitLike,
+  type PullRequestContext,
+  requestCodeownerReviewers,
+  resolvePullRequestContext,
+  upsertMatchedReasonComment,
+} from '../github.js'
+import { collectReviewersForFiles, loadCodeowners } from '../codeowners.js'
+import { writeStepSummary } from '../step-summary.js'
 
 const readFileAsync = promisify(readFile)
 
@@ -20,6 +35,8 @@ interface ClassifyOptions {
   githubToken?: string
   output?: string
   cwd: string
+  labels: boolean
+  postComment: boolean
 }
 
 function getLocalDiff(baseSha: string, headSha: string, cwd: string): DiffFile[] {
@@ -31,29 +48,23 @@ function getLocalDiff(baseSha: string, headSha: string, cwd: string): DiffFile[]
   return parseUnifiedDiff(diff)
 }
 
-async function getGitHubDiff(token: string): Promise<DiffFile[]> {
-  const repo = process.env.GITHUB_REPOSITORY
-  const eventPath = process.env.GITHUB_EVENT_PATH
-  if (!repo) throw new Error('GITHUB_REPOSITORY is not set')
-  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is not set')
-
-  const [owner, name] = repo.split('/')
-  if (!owner || !name) throw new Error(`invalid GITHUB_REPOSITORY: ${repo}`)
-
-  const event = JSON.parse(readFileSync(eventPath, 'utf8')) as {
-    pull_request?: { number: number }
-  }
-  const prNumber = event.pull_request?.number
-  if (!prNumber) throw new Error('event payload has no pull_request.number')
-
-  const { Octokit } = await import('@octokit/rest')
-  const octokit = new Octokit({ auth: token })
-  const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
-    owner,
-    repo: name,
-    pull_number: prNumber,
+async function getGitHubDiff(
+  octokit: OctokitLike,
+  ctx: PullRequestContext,
+): Promise<DiffFile[]> {
+  const files = (await octokit.paginate(octokit.rest.pulls.listFiles, {
+    owner: ctx.owner,
+    repo: ctx.repo,
+    pull_number: ctx.prNumber,
     per_page: 100,
-  })
+  })) as Array<{
+    filename: string
+    status: string
+    additions: number
+    deletions: number
+    patch?: string
+    previous_filename?: string
+  }>
 
   return files.map((f) => {
     const entry: DiffFile = {
@@ -74,7 +85,85 @@ function formatZodError(e: ZodError): string {
     .join('\n')
 }
 
-export function registerClassifyCommand(program: Command): void {
+function renderCommentBody(result: ClassifyResult): string {
+  const lines: string[] = []
+  lines.push(CLASSIFY_COMMENT_MARKER)
+  lines.push(`## Harness classify: \`${result.riskLevel.toUpperCase()}\``)
+  lines.push('')
+  lines.push(result.summary)
+  lines.push('')
+  if (result.matchedRules.length > 0) {
+    lines.push('### Matched rules')
+    for (const rule of result.matchedRules) {
+      lines.push(`- **[${rule.ruleType}] ${rule.ruleId}** — ${rule.description}`)
+      for (const m of rule.matches.slice(0, 5)) {
+        const lineInfo = m.line !== undefined ? `:${m.line}` : ''
+        lines.push(`  - \`${m.file}${lineInfo}\``)
+      }
+      if (rule.matches.length > 5) {
+        lines.push(`  - _(+${rule.matches.length - 5} more)_`)
+      }
+    }
+  }
+  return lines.join('\n')
+}
+
+export interface ClassifyCommandDeps {
+  octokitFactory?: OctokitFactory
+  env?: NodeJS.ProcessEnv
+}
+
+async function runGithubSideEffects(
+  octokit: OctokitLike,
+  ctx: PullRequestContext,
+  opts: ClassifyOptions,
+  config: HarnessConfig,
+  result: ClassifyResult,
+  files: DiffFile[],
+  cwd: string,
+): Promise<void> {
+  if (opts.labels) {
+    try {
+      await applyLabels(octokit, ctx, {
+        highRiskLabel: config.harness.auto_merge.labels.high_risk,
+        lowRiskLabel: config.harness.auto_merge.labels.low_risk,
+      }, result.riskLevel)
+    } catch (e) {
+      console.error(`label の更新に失敗: ${(e as Error).message}`)
+    }
+  }
+
+  if (opts.postComment) {
+    try {
+      await upsertMatchedReasonComment(octokit, ctx, renderCommentBody(result))
+    } catch (e) {
+      console.error(`コメント投稿に失敗: ${(e as Error).message}`)
+    }
+  }
+
+  if (result.riskLevel === 'high') {
+    try {
+      const rules = loadCodeowners(cwd)
+      if (rules.length > 0) {
+        const reviewers = collectReviewersForFiles(
+          rules,
+          files.map((f) => f.filename),
+        )
+        await requestCodeownerReviewers(octokit, ctx, reviewers)
+      }
+    } catch (e) {
+      console.error(`reviewer リクエストに失敗: ${(e as Error).message}`)
+    }
+  }
+}
+
+export function registerClassifyCommand(
+  program: Command,
+  deps: ClassifyCommandDeps = {},
+): void {
+  const octokitFactory = deps.octokitFactory ?? defaultOctokitFactory
+  const env = deps.env ?? process.env
+
   program
     .command('classify')
     .description('diff を分類して結果を出力する')
@@ -84,6 +173,8 @@ export function registerClassifyCommand(program: Command): void {
     .option('--github-token <token>', 'GitHub API トークン (PR モード)')
     .option('--output <format>', '出力フォーマット: human | json', 'human')
     .option('--cwd <path>', '作業ディレクトリ', process.cwd())
+    .option('--no-labels', 'PR の risk ラベル付与をスキップする')
+    .option('--no-post-comment', 'PR コメント投稿をスキップする')
     .action(async (opts: ClassifyOptions) => {
       const cwd = resolve(opts.cwd)
       const configPath = resolve(cwd, opts.config)
@@ -96,7 +187,7 @@ export function registerClassifyCommand(program: Command): void {
         process.exit(1)
       }
 
-      let config
+      let config: HarnessConfig
       try {
         config = HarnessConfigSchema.parse(jsYaml.load(rawConfig))
       } catch (e) {
@@ -110,9 +201,14 @@ export function registerClassifyCommand(program: Command): void {
       }
 
       let files: DiffFile[]
+      let octokit: OctokitLike | null = null
+      let ctx: PullRequestContext | null = null
+
       try {
         if (opts.githubToken) {
-          files = await getGitHubDiff(opts.githubToken)
+          ctx = resolvePullRequestContext(env)
+          octokit = await octokitFactory(opts.githubToken)
+          files = await getGitHubDiff(octokit, ctx)
         } else {
           if (!opts.baseSha) {
             console.error('--base-sha は --github-token 未指定時に必須です')
@@ -151,6 +247,16 @@ export function registerClassifyCommand(program: Command): void {
             }
           }
         }
+      }
+
+      try {
+        writeStepSummary(result, env)
+      } catch (e) {
+        console.error(`step summary の書き込みに失敗: ${(e as Error).message}`)
+      }
+
+      if (octokit && ctx) {
+        await runGithubSideEffects(octokit, ctx, opts, config, result, files, cwd)
       }
     })
 }

--- a/packages/cli/src/github.ts
+++ b/packages/cli/src/github.ts
@@ -1,0 +1,178 @@
+import { readFileSync as nodeReadFileSync } from 'node:fs'
+import type { RiskLevel } from '@butaosuinu/harness-shared'
+
+export const CLASSIFY_COMMENT_MARKER = '<!-- harness[classify] -->'
+
+export interface PullRequestContext {
+  owner: string
+  repo: string
+  prNumber: number
+}
+
+export interface OctokitLike {
+  paginate: (fn: unknown, opts: unknown) => Promise<unknown[]>
+  rest: {
+    pulls: {
+      listFiles: unknown
+      requestReviewers: (opts: {
+        owner: string
+        repo: string
+        pull_number: number
+        reviewers?: string[]
+        team_reviewers?: string[]
+      }) => Promise<unknown>
+    }
+    issues: {
+      addLabels: (opts: {
+        owner: string
+        repo: string
+        issue_number: number
+        labels: string[]
+      }) => Promise<unknown>
+      removeLabel: (opts: {
+        owner: string
+        repo: string
+        issue_number: number
+        name: string
+      }) => Promise<unknown>
+      listComments: unknown
+      createComment: (opts: {
+        owner: string
+        repo: string
+        issue_number: number
+        body: string
+      }) => Promise<unknown>
+      updateComment: (opts: {
+        owner: string
+        repo: string
+        comment_id: number
+        body: string
+      }) => Promise<unknown>
+    }
+  }
+}
+
+export type OctokitFactory = (token: string) => Promise<OctokitLike>
+
+export const defaultOctokitFactory: OctokitFactory = async (token) => {
+  const { Octokit } = await import('@octokit/rest')
+  return new Octokit({ auth: token }) as unknown as OctokitLike
+}
+
+export function resolvePullRequestContext(
+  env: NodeJS.ProcessEnv = process.env,
+  readFileSync: (path: string, encoding: 'utf8') => string = nodeReadFileSync,
+): PullRequestContext {
+  const repoSlug = env.GITHUB_REPOSITORY
+  const eventPath = env.GITHUB_EVENT_PATH
+  if (!repoSlug) throw new Error('GITHUB_REPOSITORY is not set')
+  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is not set')
+
+  const [owner, repo] = repoSlug.split('/')
+  if (!owner || !repo) throw new Error(`invalid GITHUB_REPOSITORY: ${repoSlug}`)
+
+  const event = JSON.parse(readFileSync(eventPath, 'utf8')) as {
+    pull_request?: { number: number }
+  }
+  const prNumber = event.pull_request?.number
+  if (!prNumber) throw new Error('event payload has no pull_request.number')
+
+  return { owner, repo, prNumber }
+}
+
+export async function applyLabels(
+  octokit: OctokitLike,
+  ctx: PullRequestContext,
+  cfg: { highRiskLabel: string; lowRiskLabel: string },
+  riskLevel: RiskLevel,
+): Promise<void> {
+  const toAdd = riskLevel === 'high' ? cfg.highRiskLabel : cfg.lowRiskLabel
+  const toRemove = riskLevel === 'high' ? cfg.lowRiskLabel : cfg.highRiskLabel
+
+  await octokit.rest.issues.addLabels({
+    owner: ctx.owner,
+    repo: ctx.repo,
+    issue_number: ctx.prNumber,
+    labels: [toAdd],
+  })
+
+  try {
+    await octokit.rest.issues.removeLabel({
+      owner: ctx.owner,
+      repo: ctx.repo,
+      issue_number: ctx.prNumber,
+      name: toRemove,
+    })
+  } catch (e) {
+    const status = (e as { status?: number }).status
+    if (status !== 404) throw e
+  }
+}
+
+interface IssueComment {
+  id: number
+  body?: string
+}
+
+export async function upsertMatchedReasonComment(
+  octokit: OctokitLike,
+  ctx: PullRequestContext,
+  body: string,
+): Promise<void> {
+  const comments = (await octokit.paginate(octokit.rest.issues.listComments, {
+    owner: ctx.owner,
+    repo: ctx.repo,
+    issue_number: ctx.prNumber,
+    per_page: 100,
+  })) as IssueComment[]
+
+  const existing = comments.find((c) =>
+    (c.body ?? '').includes(CLASSIFY_COMMENT_MARKER),
+  )
+
+  if (existing) {
+    await octokit.rest.issues.updateComment({
+      owner: ctx.owner,
+      repo: ctx.repo,
+      comment_id: existing.id,
+      body,
+    })
+  } else {
+    await octokit.rest.issues.createComment({
+      owner: ctx.owner,
+      repo: ctx.repo,
+      issue_number: ctx.prNumber,
+      body,
+    })
+  }
+}
+
+export async function requestCodeownerReviewers(
+  octokit: OctokitLike,
+  ctx: PullRequestContext,
+  reviewers: { users: string[]; teams: string[] },
+): Promise<void> {
+  const users = dedupe(reviewers.users)
+  const teams = dedupe(reviewers.teams)
+  if (users.length === 0 && teams.length === 0) return
+
+  const payload: {
+    owner: string
+    repo: string
+    pull_number: number
+    reviewers?: string[]
+    team_reviewers?: string[]
+  } = {
+    owner: ctx.owner,
+    repo: ctx.repo,
+    pull_number: ctx.prNumber,
+  }
+  if (users.length > 0) payload.reviewers = users
+  if (teams.length > 0) payload.team_reviewers = teams
+
+  await octokit.rest.pulls.requestReviewers(payload)
+}
+
+function dedupe(xs: string[]): string[] {
+  return Array.from(new Set(xs))
+}

--- a/packages/cli/src/step-summary.ts
+++ b/packages/cli/src/step-summary.ts
@@ -1,0 +1,43 @@
+import { appendFileSync as nodeAppendFileSync } from 'node:fs'
+import type { ClassifyResult } from '@butaosuinu/harness-shared'
+
+const MAX_MATCHES_PER_RULE = 5
+
+export function renderStepSummary(result: ClassifyResult): string {
+  const lines: string[] = []
+  lines.push('## Harness classify')
+  lines.push('')
+  lines.push(`**Risk level:** \`${result.riskLevel.toUpperCase()}\``)
+  lines.push('')
+  lines.push(`**Summary:** ${result.summary}`)
+  lines.push('')
+
+  if (result.matchedRules.length > 0) {
+    lines.push('### Matched rules')
+    lines.push('')
+    for (const rule of result.matchedRules) {
+      lines.push(`- **[${rule.ruleType}] ${rule.ruleId}** — ${rule.description}`)
+      const shown = rule.matches.slice(0, MAX_MATCHES_PER_RULE)
+      for (const m of shown) {
+        const lineInfo = m.line !== undefined ? `:${m.line}` : ''
+        lines.push(`  - \`${m.file}${lineInfo}\``)
+      }
+      if (rule.matches.length > MAX_MATCHES_PER_RULE) {
+        lines.push(`  - _(+${rule.matches.length - MAX_MATCHES_PER_RULE} more)_`)
+      }
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+export function writeStepSummary(
+  result: ClassifyResult,
+  env: NodeJS.ProcessEnv = process.env,
+  appendFileSync: (path: string, data: string) => void = nodeAppendFileSync,
+): void {
+  const target = env.GITHUB_STEP_SUMMARY
+  if (!target || target.trim() === '') return
+  appendFileSync(target, `${renderStepSummary(result)}\n`)
+}


### PR DESCRIPTION
## Summary
- `harness classify` に `--github-token` 指定時の PR 副作用を追加: risk ラベル適用 (config.auto_merge.labels 準拠 / 反対側は 404 を swallow して除去)、`<!-- harness[classify] -->` マーカー付きコメントの upsert、high-risk 時の CODEOWNERS-based reviewer リクエスト
- `GITHUB_STEP_SUMMARY` が設定されていれば token 有無によらず markdown サマリを追記
- `--no-labels` / `--no-post-comment` でオプトアウト可能
- 副作用ヘルパ (`github.ts` / `codeowners.ts` / `step-summary.ts`) を別ファイルに切り出して OctokitLike factory を注入可能にし、vitest で単体 + 統合的にテスト

## Test plan
- [x] `pnpm -r test` — 全 37 件 pass (codeowners / github / step-summary / classify-github / 既存 classify local)
- [x] `pnpm -r test:types` — shared / classifier / cli すべて pass
- [x] `pnpm --filter @butaosuinu/harness-cli build` — tsup build 成功
- [ ] GitHub Actions 実行時の手動スモーク (この PR が merge されたら別途確認)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)