### PR TITLE
ci: drop pnpm version override to fix setup failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
## Summary

- 現在オープン中の全 PR (#18, #19, #20, #21) で CI が `pnpm/action-setup@v4` 実行直後に失敗している
- 原因は `with.version: 10` と `package.json#packageManager: pnpm@10.28.2` の二重指定。`action-setup@v4` は `ERR_PNPM_BAD_PM_VERSION` 誤検知を防ぐため明示的に fail する仕様
- CLAUDE.md 方針に従い `packageManager` を単一の真実の源として残し、workflow 側の `with.version` を削除

エラー抜粋 (run 24603065261):

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.28.2 in the package.json with the key "packageManager"
```

## Test plan

- [ ] この PR 自体の CI (`test` job) が green になる
- [ ] マージ後、既存 PR #18-#21 を rebase / retry → 同ジョブが通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)