### PR TITLE
[P5] reviewer: GitHub Review API poster (#6)

### DIFF
--- a/packages/reviewer/package.json
+++ b/packages/reviewer/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
-    "@butaosuinu/harness-shared": "workspace:*"
+    "@butaosuinu/harness-shared": "workspace:*",
+    "@octokit/rest": "^21.0.2"
   },
   "devDependencies": {
     "@types/node": "^22.9.3",

--- a/packages/reviewer/src/__tests__/github.test.ts
+++ b/packages/reviewer/src/__tests__/github.test.ts
@@ -56,6 +56,28 @@ describe('computePosition', () => {
     expect(computePosition(patch, 11)).toBe(6)
     expect(computePosition(patch, 12)).toBe(7)
   })
+
+  it('does not advance newLine for `\\ No newline at end of file` markers', () => {
+    const patch = [
+      '@@ -1,2 +1,2 @@',
+      ' a',
+      '-b',
+      '+c',
+      '\\ No newline at end of file',
+    ].join('\n')
+
+    expect(computePosition(patch, 1)).toBe(1)
+    expect(computePosition(patch, 2)).toBe(3)
+    // target line 3 does not exist on the new side; marker must not pose as line 3
+    expect(computePosition(patch, 3)).toBeNull()
+  })
+
+  it('does not treat a trailing newline split artifact as a diff row', () => {
+    const patch = '@@ -1,2 +1,3 @@\n a\n+b\n c\n'
+    expect(computePosition(patch, 3)).toBe(3)
+    // a phantom 4th line would return non-null for targetLine=4
+    expect(computePosition(patch, 4)).toBeNull()
+  })
 })
 
 describe('toReviewComments', () => {
@@ -250,6 +272,33 @@ describe('postReview', () => {
     expect(payload.review_id).toBe(99)
     expect(payload.body).toContain(AI_REVIEW_COMMENT_MARKER)
     expect(payload.body).toContain('Mostly fine, a few nits.')
+  })
+
+  it('includes resolvable concerns in the update body so they are not silently dropped', async () => {
+    // updateReview only accepts a body — if we did not list resolved concerns
+    // there, a re-run that surfaced new in-diff findings would lose them.
+    const existing = {
+      id: 77,
+      body: `${AI_REVIEW_COMMENT_MARKER}\nprior content`,
+    }
+    const { octokit, updateReview } = makeOctokit([existing])
+
+    await postReview({ octokit, ctx, diff, result })
+
+    const payload = updateReview.mock.calls[0]![0]
+    // resolvable concern (src/a.ts:2) must appear in the body
+    expect(payload.body).toContain('`src/a.ts:2`')
+    expect(payload.body).toContain('**[low]** rename this')
+    // unresolved concern still listed under its own section
+    expect(payload.body).toContain('`src/b.ts:1`')
+  })
+
+  it('body lists resolvable concerns on the create path too', async () => {
+    const { octokit, createReview } = makeOctokit([])
+    await postReview({ octokit, ctx, diff, result })
+    const payload = createReview.mock.calls[0]![0]
+    expect(payload.body).toContain('### Concerns')
+    expect(payload.body).toContain('`src/a.ts:2`')
   })
 
   it('omits comments field entirely when no concern is resolvable', async () => {

--- a/packages/reviewer/src/__tests__/github.test.ts
+++ b/packages/reviewer/src/__tests__/github.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import type { DiffFile, ReviewConcern } from '@butaosuinu/harness-shared'
+import { describe, expect, it, vi } from 'vitest'
+import type { DiffFile, ReviewConcern, ReviewResult } from '@butaosuinu/harness-shared'
 
-import { computePosition, toReviewComments } from '../github.js'
+import {
+  AI_REVIEW_COMMENT_MARKER,
+  computePosition,
+  postReview,
+  toReviewComments,
+  type OctokitLike,
+  type PullRequestContext,
+} from '../github.js'
 
 describe('computePosition', () => {
   it('resolves an added line in a single hunk', () => {
@@ -116,5 +123,151 @@ describe('toReviewComments', () => {
     expect(result.comments).toHaveLength(1)
     expect(result.comments[0]!.path).toBe('src/a.ts')
     expect(result.unresolved).toEqual([unresolved1, unresolved2])
+  })
+})
+
+describe('postReview', () => {
+  const ctx: PullRequestContext = {
+    owner: 'acme',
+    repo: 'widgets',
+    prNumber: 42,
+    headSha: 'deadbeef',
+  }
+
+  const diff: DiffFile[] = [
+    {
+      filename: 'src/a.ts',
+      status: 'modified',
+      additions: 1,
+      deletions: 0,
+      patch: '@@ -1,2 +1,3 @@\n a\n+b\n c',
+    },
+    {
+      filename: 'src/b.ts',
+      status: 'added',
+      additions: 1,
+      deletions: 0,
+    },
+  ]
+
+  const result: ReviewResult = {
+    score: 85,
+    summary: 'Mostly fine, a few nits.',
+    concerns: [
+      { file: 'src/a.ts', line: 2, severity: 'low', message: 'rename this' },
+      { file: 'src/b.ts', line: 1, severity: 'medium', message: 'no patch available' },
+    ],
+    recommendation: 'request_changes',
+  }
+
+  function makeOctokit(reviews: Array<{ id: number; body: string }>): {
+    octokit: OctokitLike
+    paginate: ReturnType<typeof vi.fn>
+    createReview: ReturnType<typeof vi.fn>
+    updateReview: ReturnType<typeof vi.fn>
+  } {
+    const paginate = vi.fn().mockResolvedValue(reviews)
+    const createReview = vi.fn().mockResolvedValue({})
+    const updateReview = vi.fn().mockResolvedValue({})
+    const listReviews = { __tag: 'listReviews' } as unknown
+    const octokit: OctokitLike = {
+      paginate: paginate as unknown as OctokitLike['paginate'],
+      rest: {
+        pulls: {
+          listReviews,
+          createReview: createReview as unknown as OctokitLike['rest']['pulls']['createReview'],
+          updateReview: updateReview as unknown as OctokitLike['rest']['pulls']['updateReview'],
+        },
+      },
+    }
+    return { octokit, paginate, createReview, updateReview }
+  }
+
+  it('creates a new review with inline comments when none exists', async () => {
+    const { octokit, paginate, createReview, updateReview } = makeOctokit([])
+
+    await postReview({ octokit, ctx, diff, result })
+
+    expect(paginate).toHaveBeenCalledTimes(1)
+    expect(paginate.mock.calls[0]![1]).toEqual({
+      owner: 'acme',
+      repo: 'widgets',
+      pull_number: 42,
+      per_page: 100,
+    })
+
+    expect(updateReview).not.toHaveBeenCalled()
+    expect(createReview).toHaveBeenCalledTimes(1)
+
+    const payload = createReview.mock.calls[0]![0]
+    expect(payload.owner).toBe('acme')
+    expect(payload.repo).toBe('widgets')
+    expect(payload.pull_number).toBe(42)
+    expect(payload.commit_id).toBe('deadbeef')
+    expect(payload.event).toBe('REQUEST_CHANGES')
+    expect(payload.body).toContain(AI_REVIEW_COMMENT_MARKER)
+    expect(payload.body).toContain('Mostly fine, a few nits.')
+    expect(payload.body).toContain('**Score:** 85')
+    expect(payload.body).toContain('Concerns without resolvable diff position')
+    expect(payload.body).toContain('`src/b.ts:1`')
+
+    expect(payload.comments).toEqual([
+      { path: 'src/a.ts', position: 2, body: '**[low]** rename this' },
+    ])
+  })
+
+  it('maps approve recommendation to APPROVE event', async () => {
+    const { octokit, createReview } = makeOctokit([])
+    await postReview({
+      octokit,
+      ctx,
+      diff,
+      result: { ...result, recommendation: 'approve', concerns: [] },
+    })
+    expect(createReview).toHaveBeenCalledTimes(1)
+    expect(createReview.mock.calls[0]![0].event).toBe('APPROVE')
+    expect(createReview.mock.calls[0]![0].comments).toBeUndefined()
+  })
+
+  it('updates an existing review body when one carries the marker', async () => {
+    const existing = {
+      id: 99,
+      body: `prior\n${AI_REVIEW_COMMENT_MARKER}\nolder content`,
+    }
+    const { octokit, createReview, updateReview } = makeOctokit([
+      { id: 1, body: 'unrelated review' },
+      existing,
+    ])
+
+    await postReview({ octokit, ctx, diff, result })
+
+    expect(createReview).not.toHaveBeenCalled()
+    expect(updateReview).toHaveBeenCalledTimes(1)
+    const payload = updateReview.mock.calls[0]![0]
+    expect(payload.owner).toBe('acme')
+    expect(payload.repo).toBe('widgets')
+    expect(payload.pull_number).toBe(42)
+    expect(payload.review_id).toBe(99)
+    expect(payload.body).toContain(AI_REVIEW_COMMENT_MARKER)
+    expect(payload.body).toContain('Mostly fine, a few nits.')
+  })
+
+  it('omits comments field entirely when no concern is resolvable', async () => {
+    const { octokit, createReview } = makeOctokit([])
+    await postReview({
+      octokit,
+      ctx,
+      diff,
+      result: {
+        ...result,
+        concerns: [
+          { file: 'src/missing.ts', line: 1, severity: 'high', message: 'ghost' },
+        ],
+      },
+    })
+
+    const payload = createReview.mock.calls[0]![0]
+    expect(payload.comments).toBeUndefined()
+    expect(payload.body).toContain('`src/missing.ts:1`')
   })
 })

--- a/packages/reviewer/src/__tests__/github.test.ts
+++ b/packages/reviewer/src/__tests__/github.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import type { DiffFile, ReviewConcern } from '@butaosuinu/harness-shared'
+
+import { computePosition, toReviewComments } from '../github.js'
+
+describe('computePosition', () => {
+  it('resolves an added line in a single hunk', () => {
+    const patch = '@@ -1,2 +1,3 @@\n a\n+b\n c'
+    expect(computePosition(patch, 2)).toBe(2)
+  })
+
+  it('resolves a context line after additions and deletions', () => {
+    const patch = '@@ -1,3 +1,3 @@\n a\n-b\n+x\n c'
+    expect(computePosition(patch, 1)).toBe(1)
+    expect(computePosition(patch, 2)).toBe(3)
+    expect(computePosition(patch, 3)).toBe(4)
+  })
+
+  it('returns null when the target line never appears on the new side', () => {
+    const patch = '@@ -1,2 +1,1 @@\n a\n-b'
+    expect(computePosition(patch, 2)).toBeNull()
+  })
+
+  it('returns null for a line outside the hunk range', () => {
+    const patch = '@@ -1,2 +1,3 @@\n a\n+b\n c'
+    expect(computePosition(patch, 99)).toBeNull()
+  })
+
+  it('returns null for empty or undefined patches', () => {
+    expect(computePosition('', 1)).toBeNull()
+    expect(computePosition(undefined, 1)).toBeNull()
+  })
+
+  it('handles multiple hunks and counts subsequent hunk headers', () => {
+    const patch = [
+      '@@ -1,3 +1,3 @@',
+      ' a',
+      '+x',
+      '-b',
+      '@@ -10,2 +10,3 @@',
+      ' d',
+      '+y',
+      ' e',
+    ].join('\n')
+
+    expect(computePosition(patch, 1)).toBe(1)
+    expect(computePosition(patch, 2)).toBe(2)
+    expect(computePosition(patch, 10)).toBe(5)
+    expect(computePosition(patch, 11)).toBe(6)
+    expect(computePosition(patch, 12)).toBe(7)
+  })
+})
+
+describe('toReviewComments', () => {
+  const diff: DiffFile[] = [
+    {
+      filename: 'src/a.ts',
+      status: 'modified',
+      additions: 1,
+      deletions: 0,
+      patch: '@@ -1,2 +1,3 @@\n a\n+b\n c',
+    },
+    {
+      filename: 'src/b.ts',
+      status: 'added',
+      additions: 1,
+      deletions: 0,
+    },
+  ]
+
+  const concern = (
+    file: string,
+    line: number,
+    severity: ReviewConcern['severity'],
+    message: string,
+  ): ReviewConcern => ({ file, line, severity, message })
+
+  it('maps resolvable concerns to inline comments with severity-tagged bodies', () => {
+    const { comments, unresolved } = toReviewComments(diff, [
+      concern('src/a.ts', 2, 'low', 'extract constant'),
+    ])
+
+    expect(unresolved).toEqual([])
+    expect(comments).toEqual([
+      { path: 'src/a.ts', position: 2, body: '**[low]** extract constant' },
+    ])
+  })
+
+  it('marks concerns on files absent from the diff as unresolved', () => {
+    const c = concern('src/missing.ts', 1, 'high', 'what?')
+    const { comments, unresolved } = toReviewComments(diff, [c])
+    expect(comments).toEqual([])
+    expect(unresolved).toEqual([c])
+  })
+
+  it('marks concerns on files with no patch as unresolved', () => {
+    const c = concern('src/b.ts', 1, 'medium', 'new file no patch')
+    const { comments, unresolved } = toReviewComments(diff, [c])
+    expect(comments).toEqual([])
+    expect(unresolved).toEqual([c])
+  })
+
+  it('marks concerns whose line is outside any hunk as unresolved', () => {
+    const c = concern('src/a.ts', 99, 'low', 'out of range')
+    const { comments, unresolved } = toReviewComments(diff, [c])
+    expect(comments).toEqual([])
+    expect(unresolved).toEqual([c])
+  })
+
+  it('splits resolvable and unresolvable concerns correctly', () => {
+    const resolvable = concern('src/a.ts', 2, 'low', 'm1')
+    const unresolved1 = concern('src/b.ts', 1, 'medium', 'm2')
+    const unresolved2 = concern('src/a.ts', 99, 'high', 'm3')
+
+    const result = toReviewComments(diff, [resolvable, unresolved1, unresolved2])
+    expect(result.comments).toHaveLength(1)
+    expect(result.comments[0]!.path).toBe('src/a.ts')
+    expect(result.unresolved).toEqual([unresolved1, unresolved2])
+  })
+})

--- a/packages/reviewer/src/github.ts
+++ b/packages/reviewer/src/github.ts
@@ -1,0 +1,62 @@
+import type { DiffFile, ReviewConcern, ReviewResult } from '@butaosuinu/harness-shared'
+
+export const AI_REVIEW_COMMENT_MARKER = '<!-- harness[ai-review] -->'
+
+export interface PullRequestContext {
+  owner: string
+  repo: string
+  prNumber: number
+  headSha: string
+}
+
+export type ReviewEvent = 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT'
+
+export interface InlineComment {
+  path: string
+  position: number
+  body: string
+}
+
+export interface OctokitLike {
+  paginate: (fn: unknown, opts: unknown) => Promise<unknown[]>
+  rest: {
+    pulls: {
+      listReviews: unknown
+      createReview: (opts: {
+        owner: string
+        repo: string
+        pull_number: number
+        commit_id?: string
+        body: string
+        event: ReviewEvent
+        comments?: InlineComment[]
+      }) => Promise<unknown>
+      updateReview: (opts: {
+        owner: string
+        repo: string
+        pull_number: number
+        review_id: number
+        body: string
+      }) => Promise<unknown>
+    }
+  }
+}
+
+export type OctokitFactory = (token: string) => Promise<OctokitLike>
+
+export const defaultOctokitFactory: OctokitFactory = async (token) => {
+  const { Octokit } = await import('@octokit/rest')
+  return new Octokit({ auth: token }) as unknown as OctokitLike
+}
+
+export interface PostReviewInput {
+  octokit: OctokitLike
+  ctx: PullRequestContext
+  diff: readonly DiffFile[]
+  result: ReviewResult
+}
+
+export interface MappedComments {
+  comments: InlineComment[]
+  unresolved: ReviewConcern[]
+}

--- a/packages/reviewer/src/github.ts
+++ b/packages/reviewer/src/github.ts
@@ -58,6 +58,7 @@ export interface PostReviewInput {
 
 export interface MappedComments {
   comments: InlineComment[]
+  resolved: ReviewConcern[]
   unresolved: ReviewConcern[]
 }
 
@@ -72,7 +73,8 @@ export function computePosition(
   let newLine = 0
   let seenFirstHunk = false
 
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!
     if (line.startsWith('@@')) {
       const match = line.match(/@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/)
       if (match) newLine = Number.parseInt(match[1]!, 10) - 1
@@ -81,11 +83,15 @@ export function computePosition(
       continue
     }
     if (!seenFirstHunk) continue
+    // trailing `split('\n')` artifact when patch ends with '\n'
+    if (line === '' && i === lines.length - 1) continue
 
     position += 1
-    if (line.startsWith('-')) continue
-    newLine += 1
-    if (newLine === targetLine) return position
+    // `-` deletions and `\ No newline...` markers occupy a position slot but no new-side row
+    if (line.startsWith('+') || line.startsWith(' ')) {
+      newLine += 1
+      if (newLine === targetLine) return position
+    }
   }
 
   return null
@@ -99,6 +105,7 @@ export function toReviewComments(
   for (const file of diff) byFilename.set(file.filename, file)
 
   const comments: InlineComment[] = []
+  const resolved: ReviewConcern[] = []
   const unresolved: ReviewConcern[] = []
 
   for (const concern of concerns) {
@@ -112,6 +119,7 @@ export function toReviewComments(
       unresolved.push(concern)
       continue
     }
+    resolved.push(concern)
     comments.push({
       path: concern.file,
       position,
@@ -119,7 +127,7 @@ export function toReviewComments(
     })
   }
 
-  return { comments, unresolved }
+  return { comments, resolved, unresolved }
 }
 
 function renderConcernBody(concern: ReviewConcern): string {
@@ -128,12 +136,23 @@ function renderConcernBody(concern: ReviewConcern): string {
 
 function renderReviewBody(
   result: ReviewResult,
+  resolved: readonly ReviewConcern[],
   unresolved: readonly ReviewConcern[],
 ): string {
   const lines: string[] = [AI_REVIEW_COMMENT_MARKER, '', '## AI Review', '']
   lines.push(`**Score:** ${result.score}`)
   lines.push(`**Recommendation:** ${result.recommendation}`)
   lines.push('', result.summary)
+
+  // body carries every concern so update-path callers still surface new findings
+  if (resolved.length > 0) {
+    lines.push('', '### Concerns', '')
+    for (const concern of resolved) {
+      lines.push(
+        `- \`${concern.file}:${concern.line}\` **[${concern.severity}]** ${concern.message}`,
+      )
+    }
+  }
 
   if (unresolved.length > 0) {
     lines.push('', '### Concerns without resolvable diff position', '')
@@ -179,8 +198,8 @@ async function findExistingReview(
 
 export async function postReview(input: PostReviewInput): Promise<void> {
   const { octokit, ctx, diff, result } = input
-  const { comments, unresolved } = toReviewComments(diff, result.concerns)
-  const body = renderReviewBody(result, unresolved)
+  const { comments, resolved, unresolved } = toReviewComments(diff, result.concerns)
+  const body = renderReviewBody(result, resolved, unresolved)
 
   const existing = await findExistingReview(octokit, ctx)
 

--- a/packages/reviewer/src/github.ts
+++ b/packages/reviewer/src/github.ts
@@ -125,3 +125,83 @@ export function toReviewComments(
 function renderConcernBody(concern: ReviewConcern): string {
   return `**[${concern.severity}]** ${concern.message}`
 }
+
+function renderReviewBody(
+  result: ReviewResult,
+  unresolved: readonly ReviewConcern[],
+): string {
+  const lines: string[] = [AI_REVIEW_COMMENT_MARKER, '', '## AI Review', '']
+  lines.push(`**Score:** ${result.score}`)
+  lines.push(`**Recommendation:** ${result.recommendation}`)
+  lines.push('', result.summary)
+
+  if (unresolved.length > 0) {
+    lines.push('', '### Concerns without resolvable diff position', '')
+    for (const concern of unresolved) {
+      lines.push(
+        `- \`${concern.file}:${concern.line}\` **[${concern.severity}]** ${concern.message}`,
+      )
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function recommendationToEvent(
+  recommendation: ReviewResult['recommendation'],
+): ReviewEvent {
+  return recommendation === 'approve' ? 'APPROVE' : 'REQUEST_CHANGES'
+}
+
+interface ExistingReview {
+  id: number
+  body?: string | null
+}
+
+async function findExistingReview(
+  octokit: OctokitLike,
+  ctx: PullRequestContext,
+): Promise<ExistingReview | null> {
+  const reviews = (await octokit.paginate(octokit.rest.pulls.listReviews, {
+    owner: ctx.owner,
+    repo: ctx.repo,
+    pull_number: ctx.prNumber,
+    per_page: 100,
+  })) as ExistingReview[]
+
+  for (const review of reviews) {
+    if ((review.body ?? '').includes(AI_REVIEW_COMMENT_MARKER)) {
+      return review
+    }
+  }
+  return null
+}
+
+export async function postReview(input: PostReviewInput): Promise<void> {
+  const { octokit, ctx, diff, result } = input
+  const { comments, unresolved } = toReviewComments(diff, result.concerns)
+  const body = renderReviewBody(result, unresolved)
+
+  const existing = await findExistingReview(octokit, ctx)
+
+  if (existing) {
+    await octokit.rest.pulls.updateReview({
+      owner: ctx.owner,
+      repo: ctx.repo,
+      pull_number: ctx.prNumber,
+      review_id: existing.id,
+      body,
+    })
+    return
+  }
+
+  await octokit.rest.pulls.createReview({
+    owner: ctx.owner,
+    repo: ctx.repo,
+    pull_number: ctx.prNumber,
+    commit_id: ctx.headSha,
+    body,
+    event: recommendationToEvent(result.recommendation),
+    comments: comments.length > 0 ? comments : undefined,
+  })
+}

--- a/packages/reviewer/src/github.ts
+++ b/packages/reviewer/src/github.ts
@@ -60,3 +60,68 @@ export interface MappedComments {
   comments: InlineComment[]
   unresolved: ReviewConcern[]
 }
+
+export function computePosition(
+  patch: string | undefined,
+  targetLine: number,
+): number | null {
+  if (!patch) return null
+
+  const lines = patch.split('\n')
+  let position = 0
+  let newLine = 0
+  let seenFirstHunk = false
+
+  for (const line of lines) {
+    if (line.startsWith('@@')) {
+      const match = line.match(/@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/)
+      if (match) newLine = Number.parseInt(match[1]!, 10) - 1
+      if (seenFirstHunk) position += 1
+      seenFirstHunk = true
+      continue
+    }
+    if (!seenFirstHunk) continue
+
+    position += 1
+    if (line.startsWith('-')) continue
+    newLine += 1
+    if (newLine === targetLine) return position
+  }
+
+  return null
+}
+
+export function toReviewComments(
+  diff: readonly DiffFile[],
+  concerns: readonly ReviewConcern[],
+): MappedComments {
+  const byFilename = new Map<string, DiffFile>()
+  for (const file of diff) byFilename.set(file.filename, file)
+
+  const comments: InlineComment[] = []
+  const unresolved: ReviewConcern[] = []
+
+  for (const concern of concerns) {
+    const file = byFilename.get(concern.file)
+    if (!file || !file.patch) {
+      unresolved.push(concern)
+      continue
+    }
+    const position = computePosition(file.patch, concern.line)
+    if (position === null) {
+      unresolved.push(concern)
+      continue
+    }
+    comments.push({
+      path: concern.file,
+      position,
+      body: renderConcernBody(concern),
+    })
+  }
+
+  return { comments, unresolved }
+}
+
+function renderConcernBody(concern: ReviewConcern): string {
+  return `**[${concern.severity}]** ${concern.message}`
+}

--- a/packages/reviewer/src/index.ts
+++ b/packages/reviewer/src/index.ts
@@ -15,6 +15,22 @@ export {
   buildSystemPrompt,
   serializeDiff,
 } from './prompt.js'
+export {
+  AI_REVIEW_COMMENT_MARKER,
+  computePosition,
+  defaultOctokitFactory,
+  postReview,
+  toReviewComments,
+} from './github.js'
+export type {
+  InlineComment,
+  MappedComments,
+  OctokitFactory,
+  OctokitLike,
+  PostReviewInput,
+  PullRequestContext,
+  ReviewEvent,
+} from './github.js'
 
 export const DEFAULT_MODEL = 'claude-sonnet-4-6'
 const MAX_TOKENS = 2048

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@butaosuinu/harness-shared':
         specifier: workspace:*
         version: link:../shared
+      '@octokit/rest':
+        specifier: ^21.0.2
+        version: 21.1.1
     devDependencies:
       '@types/node':
         specifier: ^22.9.3


### PR DESCRIPTION
## Summary
- `packages/reviewer/src/github.ts` に `postReview()` を追加。`ReviewResult` を PR review として投稿する
- `computePosition()` で `DiffFile.patch` を walk し、concern の新側行番号を GitHub classic `position` に変換。multi-hunk と subsequent hunk header の position 占有、削除行 / 範囲外行の null も扱う
- `toReviewComments()` が concern を inline comment / unresolved に split。unresolved (ファイル不在、patch 無し、hunk 範囲外) は review body 末尾に markdown リストで出して silent drop を避ける
- `harness[ai-review]` マーカーで `listReviews` を paginate し、既存 review があれば `updateReview` で body 上書き、無ければ `createReview` で inline comments 付きで投稿。`recommendation` → `APPROVE` / `REQUEST_CHANGES` にマップ
- octokit を完全 mock した vitest を 15 件追加 (position 計算、mapper、create / update / approve / unresolved の 4 flow)

Closes #6

## Test plan
- [x] `pnpm --filter @butaosuinu/harness-reviewer test` — 30 tests pass
- [x] `pnpm -r test:types` — monorepo 型チェック pass
- [x] `pnpm -r build` — reviewer + 依存全部 build success
- [x] `pnpm -r test` — 全ワークスペース test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)