### PR TITLE
feat(actions): add ai-review composite action (harness review)

### DIFF
--- a/actions/ai-review/action.yml
+++ b/actions/ai-review/action.yml
@@ -1,0 +1,132 @@
+name: Harness AI Review
+description: >-
+  Runs @butaosuinu/harness-reviewer against a low-risk PR diff and exposes
+  the resulting score and recommendation as outputs for downstream jobs
+  (auto-merge gating).
+
+inputs:
+  anthropic-api-key:
+    description: Anthropic API key. Empty / unset causes the action to fail (graceful skip is tracked separately).
+    required: true
+  github-token:
+    description: GitHub token used to fetch the PR diff and upsert the review comment. Needs contents:read + pull-requests:write.
+    required: true
+  score-threshold:
+    description: Score threshold surfaced in the step summary and PR comment. Downstream gating (e.g., auto-merge) reads `score` directly and re-applies its own threshold.
+    required: false
+    default: "75"
+  config-path:
+    description: Path to .harness/config.yml (relative to the consumer repository root).
+    required: false
+    default: .harness/config.yml
+  cli-source:
+    description: |
+      Where to obtain @butaosuinu/harness-cli.
+        "npm"       — npx the published package (default; requires the package to be published).
+        "workspace" — build the CLI from the harness repo's pnpm workspace checked out alongside this action.
+                      Use this mode while the CLI is still private / unpublished.
+    required: false
+    default: npm
+  node-version:
+    description: Node.js version to set up.
+    required: false
+    default: "20"
+  pnpm-version:
+    description: pnpm version to set up (used only when cli-source == workspace).
+    required: false
+    default: "10"
+
+outputs:
+  score:
+    description: "AI review score (0-100 integer; may be 0 on fallback)."
+    value: ${{ steps.review.outputs.score }}
+  recommendation:
+    description: "'approve' or 'request_changes'."
+    value: ${{ steps.review.outputs.recommendation }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Set up pnpm (workspace mode)
+      if: inputs.cli-source == 'workspace'
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - name: Build harness-cli from workspace
+      if: inputs.cli-source == 'workspace'
+      shell: bash
+      working-directory: ${{ github.action_path }}/../..
+      run: |
+        set -euo pipefail
+        pnpm install --frozen-lockfile
+        pnpm --filter @butaosuinu/harness-cli... build
+
+    - name: Run harness review
+      id: review
+      shell: bash
+      env:
+        HARNESS_CLI_SOURCE: ${{ inputs.cli-source }}
+        HARNESS_CONFIG_PATH: ${{ inputs.config-path }}
+        HARNESS_GITHUB_TOKEN: ${{ inputs.github-token }}
+        HARNESS_SCORE_THRESHOLD: ${{ inputs.score-threshold }}
+        HARNESS_ACTION_REPO_ROOT: ${{ github.action_path }}/../..
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+      run: |
+        set -euo pipefail
+
+        if [ "$HARNESS_CLI_SOURCE" = "workspace" ]; then
+          result_json="$(
+            pnpm --dir "$HARNESS_ACTION_REPO_ROOT" \
+              --filter @butaosuinu/harness-cli exec -- \
+              harness review \
+                --config "$HARNESS_CONFIG_PATH" \
+                --github-token "$HARNESS_GITHUB_TOKEN" \
+                --score-threshold "$HARNESS_SCORE_THRESHOLD" \
+                --output json \
+                --cwd "$GITHUB_WORKSPACE"
+          )"
+        elif [ "$HARNESS_CLI_SOURCE" = "npm" ]; then
+          cd "$GITHUB_WORKSPACE"
+          result_json="$(
+            npx -y @butaosuinu/harness-cli@latest review \
+              --config "$HARNESS_CONFIG_PATH" \
+              --github-token "$HARNESS_GITHUB_TOKEN" \
+              --score-threshold "$HARNESS_SCORE_THRESHOLD" \
+              --output json
+          )"
+        else
+          echo "::error::invalid cli-source: '$HARNESS_CLI_SOURCE' (expected 'npm' or 'workspace')"
+          exit 1
+        fi
+
+        printf '%s\n' "$result_json" > "$RUNNER_TEMP/harness-review.json"
+
+        score="$(printf '%s' "$result_json" | jq -r '.score')"
+        recommendation="$(printf '%s' "$result_json" | jq -r '.recommendation')"
+
+        if [ -z "$score" ] || [ "$score" = "null" ]; then
+          echo "::error::harness review did not return a score. Raw output:"
+          printf '%s\n' "$result_json"
+          exit 1
+        fi
+        if [ -z "$recommendation" ] || [ "$recommendation" = "null" ]; then
+          echo "::error::harness review did not return a recommendation. Raw output:"
+          printf '%s\n' "$result_json"
+          exit 1
+        fi
+
+        echo "score=$score" >> "$GITHUB_OUTPUT"
+        echo "recommendation=$recommendation" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### Harness AI review"
+          echo ""
+          echo "- **Score**: \`$score\` / threshold \`$HARNESS_SCORE_THRESHOLD\`"
+          echo "- **Recommendation**: \`$recommendation\`"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@butaosuinu/harness-classifier": "workspace:*",
+    "@butaosuinu/harness-reviewer": "workspace:*",
     "@butaosuinu/harness-shared": "workspace:*",
     "@octokit/rest": "^21.0.2",
     "commander": "^12.1.0",

--- a/packages/cli/src/__tests__/review.test.ts
+++ b/packages/cli/src/__tests__/review.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Command } from 'commander'
+import type { ReviewResult } from '@butaosuinu/harness-shared'
+import { MissingApiKeyError, type ReviewInput } from '@butaosuinu/harness-reviewer'
+import { registerReviewCommand, type ReviewFn } from '../commands/review.js'
+import type { OctokitLike } from '../github.js'
+
+const configYaml = `
+harness:
+  version: "1"
+  risk_rules:
+    high:
+      file_patterns:
+        - "prisma/schema.prisma"
+    low:
+      file_patterns:
+        - "**/*.md"
+  ai_review:
+    focus_areas:
+      - "security"
+      - "logic"
+`
+
+const diffFile = {
+  filename: 'src/a.ts',
+  status: 'modified',
+  additions: 5,
+  deletions: 2,
+  patch: '@@\n+export const x = 1\n',
+}
+
+const defaultReviewResult: ReviewResult = {
+  score: 88,
+  summary: 'looks fine',
+  concerns: [
+    { file: 'src/a.ts', line: 3, severity: 'low', message: 'minor nit' },
+  ],
+  recommendation: 'approve',
+}
+
+function makeOctokit(listFilesResponse: unknown[], listCommentsResponse: unknown[] = []) {
+  const octokit: OctokitLike & {
+    paginate: ReturnType<typeof vi.fn>
+    rest: {
+      pulls: {
+        listFiles: unknown
+        requestReviewers: ReturnType<typeof vi.fn>
+      }
+      issues: {
+        addLabels: ReturnType<typeof vi.fn>
+        removeLabel: ReturnType<typeof vi.fn>
+        listComments: unknown
+        createComment: ReturnType<typeof vi.fn>
+        updateComment: ReturnType<typeof vi.fn>
+      }
+    }
+  } = {
+    paginate: vi.fn(),
+    rest: {
+      pulls: {
+        listFiles: { marker: 'listFiles' },
+        requestReviewers: vi.fn().mockResolvedValue({}),
+      },
+      issues: {
+        addLabels: vi.fn().mockResolvedValue({}),
+        removeLabel: vi.fn().mockResolvedValue({}),
+        listComments: { marker: 'listComments' },
+        createComment: vi.fn().mockResolvedValue({}),
+        updateComment: vi.fn().mockResolvedValue({}),
+      },
+    },
+  }
+  octokit.paginate.mockImplementation(async (fn: unknown) => {
+    if (fn === octokit.rest.pulls.listFiles) return listFilesResponse
+    if (fn === octokit.rest.issues.listComments) return listCommentsResponse
+    return []
+  })
+  return octokit
+}
+
+let tmpDir: string
+let summaryFile: string
+let eventFile: string
+const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'harness-review-'))
+  mkdirSync(join(tmpDir, '.harness'))
+  writeFileSync(join(tmpDir, '.harness', 'config.yml'), configYaml, 'utf8')
+  eventFile = join(tmpDir, 'event.json')
+  writeFileSync(
+    eventFile,
+    JSON.stringify({ pull_request: { number: 42 } }),
+    'utf8',
+  )
+  summaryFile = join(tmpDir, 'step-summary.md')
+  stdoutSpy.mockClear()
+  stderrSpy.mockClear()
+  consoleErrorSpy.mockClear()
+  consoleLogSpy.mockClear()
+})
+
+afterEach(() => {
+  try {
+    rmSync(tmpDir, { recursive: true, force: true })
+  } catch {}
+})
+
+function env(overrides: Partial<NodeJS.ProcessEnv> = {}): NodeJS.ProcessEnv {
+  return {
+    GITHUB_REPOSITORY: 'acme/app',
+    GITHUB_EVENT_PATH: eventFile,
+    GITHUB_STEP_SUMMARY: summaryFile,
+    ...overrides,
+  } as NodeJS.ProcessEnv
+}
+
+async function runReview(
+  octokit: OctokitLike,
+  reviewFn: ReviewFn,
+  extraArgs: string[] = [],
+  envOverrides: NodeJS.ProcessEnv = env({ ANTHROPIC_API_KEY: 'sk-test' }),
+): Promise<void> {
+  const program = new Command()
+  program.exitOverride()
+  registerReviewCommand(program, {
+    octokitFactory: async () => octokit,
+    reviewFn,
+    env: envOverrides,
+  })
+  await program.parseAsync(
+    [
+      'review',
+      '--github-token',
+      'fake',
+      '--output',
+      'json',
+      '--cwd',
+      tmpDir,
+      ...extraArgs,
+    ],
+    { from: 'user' },
+  )
+}
+
+describe('review command', () => {
+  it('writes JSON to stdout, appends step summary, and upserts a marker comment', async () => {
+    const octokit = makeOctokit([diffFile])
+    const reviewFn = vi.fn(async () => defaultReviewResult) as ReviewFn
+
+    await runReview(octokit, reviewFn)
+
+    expect(reviewFn).toHaveBeenCalledTimes(1)
+    const input = (reviewFn as unknown as {
+      mock: { calls: [ReviewInput][] }
+    }).mock.calls[0]![0]
+    expect(input.diff).toHaveLength(1)
+    expect(input.diff[0]!.filename).toBe('src/a.ts')
+    expect(input.apiKey).toBe('sk-test')
+
+    const stdoutCalls = stdoutSpy.mock.calls.map((c) => String(c[0])).join('')
+    const parsed = JSON.parse(stdoutCalls.trim()) as ReviewResult
+    expect(parsed.score).toBe(88)
+    expect(parsed.recommendation).toBe('approve')
+
+    expect(octokit.rest.issues.createComment).toHaveBeenCalledTimes(1)
+    const commentBody = (
+      octokit.rest.issues.createComment.mock.calls[0]![0] as { body: string }
+    ).body
+    expect(commentBody).toContain('<!-- harness[ai-review] -->')
+    expect(commentBody).toContain('score `88`')
+    expect(commentBody).toContain('threshold `75`')
+    expect(commentBody).toContain('approve')
+
+    const summary = readFileSync(summaryFile, 'utf8')
+    expect(summary).toContain('## Harness AI review')
+    expect(summary).toContain('`88`')
+  })
+
+  it('reads ANTHROPIC_API_KEY from the flag when env is unset', async () => {
+    const octokit = makeOctokit([diffFile])
+    const reviewFn = vi.fn(async () => defaultReviewResult) as ReviewFn
+
+    await runReview(
+      octokit,
+      reviewFn,
+      ['--anthropic-api-key', 'sk-from-flag'],
+      env({}),
+    )
+    const input = (reviewFn as unknown as {
+      mock: { calls: [ReviewInput][] }
+    }).mock.calls[0]![0]
+    expect(input.apiKey).toBe('sk-from-flag')
+  })
+
+  it('exits 1 when neither flag nor env provide the API key', async () => {
+    const octokit = makeOctokit([diffFile])
+    const reviewFn = vi.fn(async () => defaultReviewResult) as ReviewFn
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number | null) => {
+        throw new Error(`__exit_${code ?? 0}__`)
+      }) as (code?: number | null) => never)
+
+    try {
+      await expect(runReview(octokit, reviewFn, [], env({}))).rejects.toThrow(
+        /__exit_1__/,
+      )
+      expect(reviewFn).not.toHaveBeenCalled()
+      const stderr = consoleErrorSpy.mock.calls
+        .map((c) => String(c[0]))
+        .join('\n')
+      expect(stderr).toMatch(/ANTHROPIC_API_KEY/)
+    } finally {
+      exitSpy.mockRestore()
+    }
+  })
+
+  it('exits 1 when the reviewer throws MissingApiKeyError', async () => {
+    const octokit = makeOctokit([diffFile])
+    const reviewFn = vi.fn(async () => {
+      throw new MissingApiKeyError()
+    }) as ReviewFn
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number | null) => {
+        throw new Error(`__exit_${code ?? 0}__`)
+      }) as (code?: number | null) => never)
+
+    try {
+      await expect(runReview(octokit, reviewFn)).rejects.toThrow(/__exit_1__/)
+      const stderr = consoleErrorSpy.mock.calls
+        .map((c) => String(c[0]))
+        .join('\n')
+      expect(stderr).toMatch(/ANTHROPIC_API_KEY/)
+    } finally {
+      exitSpy.mockRestore()
+    }
+  })
+
+  it('respects --no-post-comment', async () => {
+    const octokit = makeOctokit([diffFile])
+    const reviewFn = vi.fn(async () => defaultReviewResult) as ReviewFn
+
+    await runReview(octokit, reviewFn, ['--no-post-comment'])
+    expect(octokit.rest.issues.createComment).not.toHaveBeenCalled()
+    expect(octokit.rest.issues.updateComment).not.toHaveBeenCalled()
+  })
+
+  it('updates an existing harness[ai-review] comment instead of creating a new one', async () => {
+    const octokit = makeOctokit(
+      [diffFile],
+      [
+        { id: 11, body: 'unrelated' },
+        { id: 99, body: '<!-- harness[ai-review] -->\nold body' },
+        { id: 200, body: '<!-- harness[classify] -->\nclassify comment (must not touch)' },
+      ],
+    )
+    const reviewFn = vi.fn(async () => defaultReviewResult) as ReviewFn
+
+    await runReview(octokit, reviewFn)
+
+    expect(octokit.rest.issues.updateComment).toHaveBeenCalledTimes(1)
+    expect(octokit.rest.issues.updateComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 99 }),
+    )
+    expect(octokit.rest.issues.createComment).not.toHaveBeenCalled()
+  })
+
+  it('passes --model through to the reviewer', async () => {
+    const octokit = makeOctokit([diffFile])
+    const reviewFn = vi.fn(async () => defaultReviewResult) as ReviewFn
+
+    await runReview(octokit, reviewFn, ['--model', 'claude-opus-4-7'])
+    const input = (reviewFn as unknown as {
+      mock: { calls: [ReviewInput][] }
+    }).mock.calls[0]![0]
+    expect(input.model).toBe('claude-opus-4-7')
+  })
+})

--- a/packages/cli/src/commands/classify.ts
+++ b/packages/cli/src/commands/classify.ts
@@ -16,6 +16,7 @@ import {
   applyLabels,
   CLASSIFY_COMMENT_MARKER,
   defaultOctokitFactory,
+  getGitHubDiff,
   type OctokitFactory,
   type OctokitLike,
   type PullRequestContext,
@@ -46,37 +47,6 @@ function getLocalDiff(baseSha: string, headSha: string, cwd: string): DiffFile[]
     maxBuffer: 64 * 1024 * 1024,
   })
   return parseUnifiedDiff(diff)
-}
-
-async function getGitHubDiff(
-  octokit: OctokitLike,
-  ctx: PullRequestContext,
-): Promise<DiffFile[]> {
-  const files = (await octokit.paginate(octokit.rest.pulls.listFiles, {
-    owner: ctx.owner,
-    repo: ctx.repo,
-    pull_number: ctx.prNumber,
-    per_page: 100,
-  })) as Array<{
-    filename: string
-    status: string
-    additions: number
-    deletions: number
-    patch?: string
-    previous_filename?: string
-  }>
-
-  return files.map((f) => {
-    const entry: DiffFile = {
-      filename: f.filename,
-      status: f.status === 'renamed' ? 'renamed' : (f.status as DiffFile['status']),
-      additions: f.additions,
-      deletions: f.deletions,
-    }
-    if (f.patch !== undefined) entry.patch = f.patch
-    if (f.previous_filename !== undefined) entry.previousFilename = f.previous_filename
-    return entry
-  })
 }
 
 function formatZodError(e: ZodError): string {

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1,0 +1,228 @@
+import { readFile } from 'node:fs'
+import { promisify } from 'node:util'
+import { resolve } from 'node:path'
+import type { Command } from 'commander'
+import jsYaml from 'js-yaml'
+import {
+  HarnessConfigSchema,
+  type HarnessConfig,
+  type ReviewResult,
+} from '@butaosuinu/harness-shared'
+import {
+  MissingApiKeyError,
+  review as defaultReview,
+  type ReviewInput,
+} from '@butaosuinu/harness-reviewer'
+import { ZodError } from 'zod'
+import {
+  AI_REVIEW_COMMENT_MARKER,
+  defaultOctokitFactory,
+  getGitHubDiff,
+  type OctokitFactory,
+  type OctokitLike,
+  type PullRequestContext,
+  resolvePullRequestContext,
+  upsertAiReviewComment,
+} from '../github.js'
+import { writeReviewStepSummary } from '../step-summary.js'
+
+const readFileAsync = promisify(readFile)
+
+const DEFAULT_SCORE_THRESHOLD = 75
+const MAX_COMMENT_CONCERNS = 10
+
+interface ReviewOptions {
+  config: string
+  githubToken: string
+  anthropicApiKey?: string
+  scoreThreshold: string
+  model?: string
+  output?: string
+  cwd: string
+  postComment: boolean
+}
+
+export type ReviewFn = (input: ReviewInput) => Promise<ReviewResult>
+
+export interface ReviewCommandDeps {
+  octokitFactory?: OctokitFactory
+  reviewFn?: ReviewFn
+  env?: NodeJS.ProcessEnv
+}
+
+function formatZodError(e: ZodError): string {
+  return e.issues
+    .map((i) => `  - ${i.path.join('.') || '(root)'}: ${i.message}`)
+    .join('\n')
+}
+
+function parseThreshold(raw: string): number {
+  const n = Number(raw)
+  if (!Number.isFinite(n)) {
+    throw new Error(`--score-threshold must be a number, got: ${raw}`)
+  }
+  return n
+}
+
+function renderCommentBody(result: ReviewResult, threshold: number): string {
+  const verdict = result.score >= threshold ? 'PASS' : 'BELOW THRESHOLD'
+  const lines: string[] = []
+  lines.push(AI_REVIEW_COMMENT_MARKER)
+  lines.push(
+    `## Harness AI review: score \`${result.score}\` / threshold \`${threshold}\` — ${verdict}`,
+  )
+  lines.push('')
+  lines.push(`**Recommendation:** \`${result.recommendation}\``)
+  lines.push('')
+  lines.push(result.summary)
+  if (result.concerns.length > 0) {
+    lines.push('')
+    lines.push('### Concerns')
+    const shown = result.concerns.slice(0, MAX_COMMENT_CONCERNS)
+    for (const c of shown) {
+      const loc = c.line > 0 ? `${c.file}:${c.line}` : c.file
+      lines.push(`- **[${c.severity}]** \`${loc}\` — ${c.message}`)
+    }
+    if (result.concerns.length > MAX_COMMENT_CONCERNS) {
+      lines.push(`- _(+${result.concerns.length - MAX_COMMENT_CONCERNS} more)_`)
+    }
+  }
+  return lines.join('\n')
+}
+
+export function registerReviewCommand(
+  program: Command,
+  deps: ReviewCommandDeps = {},
+): void {
+  const octokitFactory = deps.octokitFactory ?? defaultOctokitFactory
+  const reviewFn = deps.reviewFn ?? defaultReview
+  const env = deps.env ?? process.env
+
+  program
+    .command('review')
+    .description('low-risk PR に対して AI レビューを実行する')
+    .option('--config <path>', 'config.yml のパス', '.harness/config.yml')
+    .requiredOption('--github-token <token>', 'GitHub API トークン')
+    .option(
+      '--anthropic-api-key <key>',
+      'Anthropic API key (未指定時は env.ANTHROPIC_API_KEY を参照)',
+    )
+    .option(
+      '--score-threshold <number>',
+      'auto-merge の閾値 (表示のみ、recommendation は上書きしない)',
+      String(DEFAULT_SCORE_THRESHOLD),
+    )
+    .option('--model <model>', 'reviewer の model override')
+    .option('--output <format>', '出力フォーマット: human | json', 'human')
+    .option('--cwd <path>', '作業ディレクトリ', process.cwd())
+    .option('--no-post-comment', 'PR コメント投稿をスキップする')
+    .action(async (opts: ReviewOptions) => {
+      const cwd = resolve(opts.cwd)
+      const configPath = resolve(cwd, opts.config)
+
+      let threshold: number
+      try {
+        threshold = parseThreshold(opts.scoreThreshold)
+      } catch (e) {
+        console.error((e as Error).message)
+        process.exit(1)
+      }
+
+      const apiKey = opts.anthropicApiKey ?? env.ANTHROPIC_API_KEY ?? ''
+      if (!apiKey || apiKey.trim() === '') {
+        console.error('ANTHROPIC_API_KEY is not set')
+        process.exit(1)
+      }
+
+      let rawConfig: string
+      try {
+        rawConfig = await readFileAsync(configPath, 'utf8')
+      } catch {
+        console.error(`config.yml が見つかりません: ${configPath}`)
+        process.exit(1)
+      }
+
+      let config: HarnessConfig
+      try {
+        config = HarnessConfigSchema.parse(jsYaml.load(rawConfig))
+      } catch (e) {
+        if (e instanceof ZodError) {
+          console.error('config.yml のバリデーションに失敗:')
+          console.error(formatZodError(e))
+        } else {
+          console.error(`config.yml のパースに失敗: ${(e as Error).message}`)
+        }
+        process.exit(1)
+      }
+
+      let octokit: OctokitLike
+      let ctx: PullRequestContext
+      try {
+        ctx = resolvePullRequestContext(env)
+        octokit = await octokitFactory(opts.githubToken)
+      } catch (e) {
+        console.error(`PR コンテキストの解決に失敗: ${(e as Error).message}`)
+        process.exit(2)
+      }
+
+      let files
+      try {
+        files = await getGitHubDiff(octokit, ctx)
+      } catch (e) {
+        console.error(`diff の取得に失敗: ${(e as Error).message}`)
+        process.exit(2)
+      }
+
+      let result: ReviewResult
+      try {
+        const input: ReviewInput = {
+          diff: files,
+          config,
+          apiKey,
+          ...(opts.model !== undefined ? { model: opts.model } : {}),
+        }
+        result = await reviewFn(input)
+      } catch (e) {
+        if (e instanceof MissingApiKeyError) {
+          console.error('ANTHROPIC_API_KEY is not set')
+          process.exit(1)
+        }
+        throw e
+      }
+
+      if (opts.output === 'json') {
+        process.stdout.write(JSON.stringify(result))
+        process.stdout.write('\n')
+      } else {
+        console.log(`Score: ${result.score} / threshold ${threshold}`)
+        console.log(`Recommendation: ${result.recommendation}`)
+        console.log(`Summary: ${result.summary}`)
+        if (result.concerns.length > 0) {
+          console.log('')
+          console.log('Concerns:')
+          for (const c of result.concerns.slice(0, MAX_COMMENT_CONCERNS)) {
+            const loc = c.line > 0 ? `${c.file}:${c.line}` : c.file
+            console.log(`  [${c.severity}] ${loc} — ${c.message}`)
+          }
+        }
+      }
+
+      try {
+        writeReviewStepSummary(result, threshold, env)
+      } catch (e) {
+        console.error(`step summary の書き込みに失敗: ${(e as Error).message}`)
+      }
+
+      if (opts.postComment) {
+        try {
+          await upsertAiReviewComment(
+            octokit,
+            ctx,
+            renderCommentBody(result, threshold),
+          )
+        } catch (e) {
+          console.error(`コメント投稿に失敗: ${(e as Error).message}`)
+        }
+      }
+    })
+}

--- a/packages/cli/src/github.ts
+++ b/packages/cli/src/github.ts
@@ -1,7 +1,8 @@
 import { readFileSync as nodeReadFileSync } from 'node:fs'
-import type { RiskLevel } from '@butaosuinu/harness-shared'
+import type { DiffFile, RiskLevel } from '@butaosuinu/harness-shared'
 
 export const CLASSIFY_COMMENT_MARKER = '<!-- harness[classify] -->'
+export const AI_REVIEW_COMMENT_MARKER = '<!-- harness[ai-review] -->'
 
 export interface PullRequestContext {
   owner: string
@@ -114,9 +115,10 @@ interface IssueComment {
   body?: string
 }
 
-export async function upsertMatchedReasonComment(
+async function upsertMarkedComment(
   octokit: OctokitLike,
   ctx: PullRequestContext,
+  marker: string,
   body: string,
 ): Promise<void> {
   const comments = (await octokit.paginate(octokit.rest.issues.listComments, {
@@ -126,9 +128,7 @@ export async function upsertMatchedReasonComment(
     per_page: 100,
   })) as IssueComment[]
 
-  const existing = comments.find((c) =>
-    (c.body ?? '').includes(CLASSIFY_COMMENT_MARKER),
-  )
+  const existing = comments.find((c) => (c.body ?? '').includes(marker))
 
   if (existing) {
     await octokit.rest.issues.updateComment({
@@ -145,6 +145,55 @@ export async function upsertMatchedReasonComment(
       body,
     })
   }
+}
+
+export function upsertMatchedReasonComment(
+  octokit: OctokitLike,
+  ctx: PullRequestContext,
+  body: string,
+): Promise<void> {
+  return upsertMarkedComment(octokit, ctx, CLASSIFY_COMMENT_MARKER, body)
+}
+
+export function upsertAiReviewComment(
+  octokit: OctokitLike,
+  ctx: PullRequestContext,
+  body: string,
+): Promise<void> {
+  return upsertMarkedComment(octokit, ctx, AI_REVIEW_COMMENT_MARKER, body)
+}
+
+interface PullFileApiResponse {
+  filename: string
+  status: string
+  additions: number
+  deletions: number
+  patch?: string
+  previous_filename?: string
+}
+
+export async function getGitHubDiff(
+  octokit: OctokitLike,
+  ctx: PullRequestContext,
+): Promise<DiffFile[]> {
+  const files = (await octokit.paginate(octokit.rest.pulls.listFiles, {
+    owner: ctx.owner,
+    repo: ctx.repo,
+    pull_number: ctx.prNumber,
+    per_page: 100,
+  })) as PullFileApiResponse[]
+
+  return files.map((f) => {
+    const entry: DiffFile = {
+      filename: f.filename,
+      status: f.status === 'renamed' ? 'renamed' : (f.status as DiffFile['status']),
+      additions: f.additions,
+      deletions: f.deletions,
+    }
+    if (f.patch !== undefined) entry.patch = f.patch
+    if (f.previous_filename !== undefined) entry.previousFilename = f.previous_filename
+    return entry
+  })
 }
 
 export async function requestCodeownerReviewers(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { registerInitCommand } from './commands/init.js'
 import { registerClassifyCommand } from './commands/classify.js'
+import { registerReviewCommand } from './commands/review.js'
 import { registerRulesCommand } from './commands/rules.js'
 
 const program = new Command()
@@ -12,6 +13,7 @@ program
 
 registerInitCommand(program)
 registerClassifyCommand(program)
+registerReviewCommand(program)
 registerRulesCommand(program)
 
 program.parseAsync(process.argv).catch((err) => {

--- a/packages/cli/src/step-summary.ts
+++ b/packages/cli/src/step-summary.ts
@@ -1,7 +1,8 @@
 import { appendFileSync as nodeAppendFileSync } from 'node:fs'
-import type { ClassifyResult } from '@butaosuinu/harness-shared'
+import type { ClassifyResult, ReviewResult } from '@butaosuinu/harness-shared'
 
 const MAX_MATCHES_PER_RULE = 5
+const MAX_CONCERNS_SHOWN = 10
 
 export function renderStepSummary(result: ClassifyResult): string {
   const lines: string[] = []
@@ -40,4 +41,49 @@ export function writeStepSummary(
   const target = env.GITHUB_STEP_SUMMARY
   if (!target || target.trim() === '') return
   appendFileSync(target, `${renderStepSummary(result)}\n`)
+}
+
+export function renderReviewStepSummary(
+  result: ReviewResult,
+  threshold: number,
+): string {
+  const verdict = result.score >= threshold ? 'PASS' : 'BELOW THRESHOLD'
+  const lines: string[] = []
+  lines.push('## Harness AI review')
+  lines.push('')
+  lines.push(`**Score:** \`${result.score}\` / threshold \`${threshold}\` — ${verdict}`)
+  lines.push('')
+  lines.push(`**Recommendation:** \`${result.recommendation}\``)
+  lines.push('')
+  lines.push(`**Summary:** ${result.summary}`)
+  lines.push('')
+
+  if (result.concerns.length > 0) {
+    lines.push('### Concerns')
+    lines.push('')
+    const shown = result.concerns.slice(0, MAX_CONCERNS_SHOWN)
+    for (const c of shown) {
+      const loc = c.line > 0 ? `${c.file}:${c.line}` : c.file
+      lines.push(`- **[${c.severity}]** \`${loc}\` — ${c.message}`)
+    }
+    if (result.concerns.length > MAX_CONCERNS_SHOWN) {
+      lines.push(
+        `- _(+${result.concerns.length - MAX_CONCERNS_SHOWN} more)_`,
+      )
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+export function writeReviewStepSummary(
+  result: ReviewResult,
+  threshold: number,
+  env: NodeJS.ProcessEnv = process.env,
+  appendFileSync: (path: string, data: string) => void = nodeAppendFileSync,
+): void {
+  const target = env.GITHUB_STEP_SUMMARY
+  if (!target || target.trim() === '') return
+  appendFileSync(target, `${renderReviewStepSummary(result, threshold)}\n`)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@butaosuinu/harness-classifier':
         specifier: workspace:*
         version: link:../classifier
+      '@butaosuinu/harness-reviewer':
+        specifier: workspace:*
+        version: link:../reviewer
       '@butaosuinu/harness-shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary
- `@butaosuinu/harness-reviewer` を low-risk PR に対して走らせる `actions/ai-review/action.yml` を追加。`score` / `recommendation` を outputs で公開し、下流の auto-merge ジョブから参照可能にする。
- そのための CLI エントリとして `harness review` サブコマンドを追加 (`packages/cli/src/commands/review.ts`)。diff 取得 (`getGitHubDiff`) と marker 付き PR コメント upsert (`upsertAiReviewComment` / `harness[ai-review]`) は `packages/cli/src/github.ts` 側で classify と共有する形にリファクタ。
- `ANTHROPIC_API_KEY` 未設定は CLI が exit 1 する設計 (flag も env も無い場合、もしくは reviewer が `MissingApiKeyError` を投げた場合)。graceful skip は #17 で別途対応。

## 変更ファイル
- `packages/cli/src/github.ts` — `AI_REVIEW_COMMENT_MARKER` 追加、`getGitHubDiff` export、upsert を marker 引数化して `upsertAiReviewComment` 追加
- `packages/cli/src/commands/classify.ts` — 共有化された `getGitHubDiff` を import
- `packages/cli/src/commands/review.ts` — 新規 subcommand
- `packages/cli/src/step-summary.ts` — `renderReviewStepSummary` / `writeReviewStepSummary`
- `packages/cli/src/index.ts` — `review` を登録
- `packages/cli/package.json` — `@butaosuinu/harness-reviewer` を workspace dep に追加
- `actions/ai-review/action.yml` — composite action (cli-source = npm | workspace 両対応、classify action と同じ構造)
- `packages/cli/src/__tests__/review.test.ts` — happy path / flag から api key / env から api key / exit 1 (flag+env 無し) / exit 1 (`MissingApiKeyError`) / `--no-post-comment` / 既存 marker コメント更新 / `--model` の 7 ケース

## Test plan
- [x] `pnpm install`
- [x] `pnpm -r build`
- [x] `pnpm -r test:types`
- [x] `pnpm -r test` — 全 44 テスト (うち review: 7、github / step-summary / classify / classify-github はリファクタ後もグリーン)
- [x] 手動スモーク: `ANTHROPIC_API_KEY="" node packages/cli/dist/index.js review --config /tmp/nope/config.yml --github-token fake --output json --cwd /tmp/nope` → exit 1、stderr に `ANTHROPIC_API_KEY is not set`
- [ ] (follow-up) `templates/workflows/harness-check.yml` への組込みと workflow レベルでの score threshold ゲート

Closes #9