### PR TITLE
[P4] templates/workflows/harness-check.yml + self-dogfood wiring

### DIFF
--- a/.github/workflows/harness-check.yml
+++ b/.github/workflows/harness-check.yml
@@ -1,0 +1,49 @@
+name: Harness Check (dogfood)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: harness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      risk-level: ${{ steps.classify.outputs.risk-level }}
+      match-summary: ${{ steps.classify.outputs.match-summary }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: classify
+        uses: ./actions/classify
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cli-source: workspace
+
+  ai-review:
+    needs: classify
+    if: needs.classify.outputs.risk-level == 'low'
+    runs-on: ubuntu-latest
+    outputs:
+      score: ${{ steps.review.outputs.score }}
+      recommendation: ${{ steps.review.outputs.recommendation }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: review
+        uses: ./actions/ai-review
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cli-source: workspace

--- a/.harness/config.yml
+++ b/.harness/config.yml
@@ -1,0 +1,36 @@
+harness:
+  version: "1"
+  stack: {}
+  risk_rules:
+    high:
+      file_patterns:
+        - ".env*"
+        - "**/secrets/**"
+        - "**/*.pem"
+        - "**/*.key"
+      ast_rules: []
+      dependency_rules:
+        added_packages: []
+      diff_size:
+        max_files: 20
+        max_lines: 500
+    low:
+      file_patterns:
+        - "**/*.test.ts"
+        - "**/*.spec.ts"
+        - "**/*.test.js"
+        - "**/*.spec.js"
+        - "**/*.md"
+        - "**/*.mdx"
+  auto_merge:
+    enabled: false
+    require_ci_pass: true
+    ai_score_threshold: 75
+    strategy: squash
+  ai_review:
+    focus_areas:
+      - "security vulnerabilities"
+      - "logic errors"
+      - "performance regressions"
+      - "breaking API changes"
+    max_diff_tokens: 8000

--- a/templates/workflows/harness-check.yml
+++ b/templates/workflows/harness-check.yml
@@ -1,0 +1,59 @@
+name: Harness Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: harness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      risk-level: ${{ steps.classify.outputs.risk-level }}
+      match-summary: ${{ steps.classify.outputs.match-summary }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: classify
+        uses: butaosuinu/code-review-harness/actions/classify@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  ai-review:
+    needs: classify
+    if: needs.classify.outputs.risk-level == 'low'
+    runs-on: ubuntu-latest
+    outputs:
+      score: ${{ steps.review.outputs.score }}
+      recommendation: ${{ steps.review.outputs.recommendation }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - id: review
+        uses: butaosuinu/code-review-harness/actions/ai-review@main
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  auto-merge:
+    needs: [classify, ai-review]
+    if: |
+      needs.classify.outputs.risk-level == 'low' &&
+      fromJSON(needs.ai-review.outputs.score) >= 75
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: butaosuinu/code-review-harness/actions/auto-merge@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `templates/workflows/harness-check.yml` — the consumer-facing GHA workflow template wiring `classify` → `ai-review` → `auto-merge` per plan.md L387-444, with `concurrency: harness-${{ github.ref }}` (cancel-in-progress) and minimum per-job permissions.
- Add `.harness/config.yml` (copied from `templates/configs/base.yml`) so this repo can consume the harness against its own PRs.
- Add `.github/workflows/harness-check.yml` — dogfood workflow that runs `classify` + `ai-review` via local `./actions/<name>` refs with `cli-source: workspace` (since `@butaosuinu/harness-cli` is not yet published to npm). `auto-merge` is intentionally omitted from dogfood so human review gates harness releases.

Notes / deviations from issue text:
- Issue body quotes `butaosuinu/code-review-harness/.github/actions/<name>@main`, but the composite actions actually live at `actions/<name>/action.yml` (top-level). The template uses the real path.
- Dogfood `ai-review` job will hard-fail until `ANTHROPIC_API_KEY` is set in repo secrets (graceful skip is tracked as #17).

Closes #11

## Test plan
- [ ] `pnpm install --frozen-lockfile` clean
- [ ] `pnpm -r build` green
- [ ] `pnpm -r test:types` green
- [ ] `pnpm -r test` green (all 34 + 24 + 44 + auto-merge tests)
- [ ] YAML parse of all three new files via `js-yaml` passes
- [ ] On this PR itself: `Harness Check (dogfood)` workflow runs → `classify` job green → `ai-review` job green (requires `ANTHROPIC_API_KEY` secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)